### PR TITLE
Fix json open-api definition file not supporting issue. 

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/generators/GeneratorUtils.java
+++ b/openapi-cli/src/main/java/io/ballerina/generators/GeneratorUtils.java
@@ -414,9 +414,8 @@ public class GeneratorUtils {
         if (!Files.exists(contractPath)) {
             throw new BallerinaOpenApiException(ErrorMessages.invalidFilePath(definitionPath.toString()));
         }
-        if (!(definitionPath.toString().endsWith(".yaml") || definitionPath.endsWith(".json") ||
-                definitionPath.toString().endsWith(
-                ".yml"))) {
+        if (!(definitionPath.toString().endsWith(".yaml") || definitionPath.toString().endsWith(".json") ||
+                definitionPath.toString().endsWith(".yml"))) {
             throw new BallerinaOpenApiException(ErrorMessages.invalidFileType());
         }
         String openAPIFileContent = Files.readString(definitionPath);


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-openapi/issues/376

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes