### PR TITLE
Add implementation to select `https` server url and update header map key name format

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -310,28 +310,33 @@ public class BallerinaClientGenerator {
     /**
      * Generate serverUrl for client default value.
      */
-    private static String getServerURL(Server server) throws BallerinaOpenApiException {
+    private static String getServerURL(List<Server> servers) throws BallerinaOpenApiException {
         String serverURL;
-        GeneratorUtils generatorUtils = new GeneratorUtils();
-        if (server != null) {
-            if (server.getUrl() == null) {
-                serverURL = "http://localhost:9090/v1";
-            } else if (server.getVariables() != null) {
-                ServerVariables variables = server.getVariables();
-                URL url;
-                String resolvedUrl = generatorUtils.buildUrl(server.getUrl(), variables);
-                try {
-                    url = new URL(resolvedUrl);
-                    serverURL = url.toString();
-                } catch (MalformedURLException e) {
-                    throw new BallerinaOpenApiException("Failed to read endpoint details of the server: " +
-                            server.getUrl(), e);
+        Server selectedServer = servers.get(0);
+        if (!selectedServer.getUrl().startsWith("https:") && servers.size() > 1) {
+            for (Server server : servers) {
+                if (server.getUrl().startsWith("https:")) {
+                    selectedServer = server;
+                    break;
                 }
-            } else {
-                serverURL = server.getUrl();
+            }
+        }
+        GeneratorUtils generatorUtils = new GeneratorUtils();
+        if (selectedServer.getUrl() == null) {
+            serverURL = "http://localhost:9090/v1";
+        } else if (selectedServer.getVariables() != null) {
+            ServerVariables variables = selectedServer.getVariables();
+            URL url;
+            String resolvedUrl = generatorUtils.buildUrl(selectedServer.getUrl(), variables);
+            try {
+                url = new URL(resolvedUrl);
+                serverURL = url.toString();
+            } catch (MalformedURLException e) {
+                throw new BallerinaOpenApiException("Failed to read endpoint details of the server: " +
+                        selectedServer.getUrl(), e);
             }
         } else {
-            serverURL = "http://localhost:9090/v1";
+            serverURL = selectedServer.getUrl();
         }
         return  serverURL;
     }
@@ -444,14 +449,13 @@ public class BallerinaClientGenerator {
                 createIdentifierToken("string"));
         IdentifierToken paramName = createIdentifierToken(GeneratorConstants.SERVICE_URL);
         List<Server> servers = openAPI.getServers();
-        Server server = servers.get(0);
-        serverURL = getServerURL(server);
+        serverURL = getServerURL(servers);
         if (serverURL.equals("/")) {
             RequiredParameterNode serviceUrl = createRequiredParameterNode(annotationNodes, typeName, paramName);
             parameters.add(serviceUrl);
         } else {
             BasicLiteralNode expression = createBasicLiteralNode(STRING_LITERAL,
-                createIdentifierToken('"' + getServerURL(server) + '"'));
+                createIdentifierToken('"' + serverURL + '"'));
             DefaultableParameterNode serviceUrl = createDefaultableParameterNode(annotationNodes, typeName,
                     paramName, createIdentifierToken("="), expression);
             parameters.add(serviceUrl);

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -705,8 +705,8 @@ public class BallerinaClientGenerator {
         IdentifierToken functionName = createIdentifierToken(" getMapForHeaders");
         FunctionSignatureNode functionSignatureNode = createFunctionSignatureNode(createToken(OPEN_PAREN_TOKEN),
                 createSeparatedNodeList(createRequiredParameterNode(createEmptyNodeList(),
-                        createIdentifierToken("map<any> "),
-                        createIdentifierToken(" headerParam"))),
+                        createIdentifierToken("map<any>"),
+                        createIdentifierToken("headerParam"))),
                 createToken(CLOSE_PAREN_TOKEN),
                 createReturnTypeDescriptorNode(createIdentifierToken(" returns "),
                         createEmptyNodeList(), createBuiltinSimpleNameReferenceNode(
@@ -814,8 +814,8 @@ public class BallerinaClientGenerator {
         IdentifierToken functionName = createIdentifierToken(" getPathForQueryParam");
         FunctionSignatureNode functionSignatureNode = createFunctionSignatureNode(createToken(OPEN_PAREN_TOKEN),
                 createSeparatedNodeList(createRequiredParameterNode(createEmptyNodeList(),
-                        createIdentifierToken("map<anydata> "),
-                        createIdentifierToken(" queryParam"))),
+                        createIdentifierToken("map<anydata>"),
+                        createIdentifierToken("queryParam"))),
                 createToken(CLOSE_PAREN_TOKEN),
                 createReturnTypeDescriptorNode(createIdentifierToken(" returns "),
                         createEmptyNodeList(), createBuiltinSimpleNameReferenceNode(

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -220,7 +220,7 @@ public class FunctionBodyGenerator {
 
             if (!queryParameters.isEmpty() || !queryApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(queryParameters, "map<anydata>",
-                        "queryParam", queryApiKeyNameList, false));
+                        "queryParam", queryApiKeyNameList));
                 // Add updated path
                 ExpressionStatementNode updatedPath = generatorUtils.getSimpleExpressionStatementNode(
                         "path = path + check getPathForQueryParam(queryParam)");
@@ -230,7 +230,7 @@ public class FunctionBodyGenerator {
 
             if (!headerParameters.isEmpty() || !headerApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(headerParameters, "map<any>",
-                        "headerValues", headerApiKeyNameList, true));
+                        "headerValues", headerApiKeyNameList));
                 statementsList.add(generatorUtils.getSimpleExpressionStatementNode(
                         "map<string|string[]> accHeaders = getMapForHeaders(headerValues)"));
                 isHeader = true;
@@ -241,7 +241,7 @@ public class FunctionBodyGenerator {
 
             if (!queryApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(new ArrayList<>(), "map<anydata>",
-                        "queryParam", queryApiKeyNameList, false));
+                        "queryParam", queryApiKeyNameList));
                 // Add updated path
                 ExpressionStatementNode updatedPath = generatorUtils.getSimpleExpressionStatementNode(
                         "path = path + check getPathForQueryParam(queryParam)");
@@ -250,7 +250,7 @@ public class FunctionBodyGenerator {
             }
             if (!headerApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(new ArrayList<>(), "map<any>",
-                        "headerValues", headerApiKeyNameList, true));
+                        "headerValues", headerApiKeyNameList));
                 statementsList.add(generatorUtils.getSimpleExpressionStatementNode(
                         "map<string|string[]> accHeaders = getMapForHeaders(headerValues)"));
                 isHeader = true;
@@ -514,8 +514,7 @@ public class FunctionBodyGenerator {
      * Generate map variable for query parameters and headers.
      */
     private VariableDeclarationNode getMapForParameters(List<Parameter> parameters, String mapDataType,
-                                                         String mapName, List<String> apiKeyNames,
-                                                         boolean isHeader) {
+                                                         String mapName, List<String> apiKeyNames) {
         List<Node> filedOfMap = new ArrayList();
         BuiltinSimpleNameReferenceNode mapType = createBuiltinSimpleNameReferenceNode(null,
                 createIdentifierToken(mapDataType));
@@ -537,13 +536,13 @@ public class FunctionBodyGenerator {
 
         if (!apiKeyNames.isEmpty()) {
             for (String apiKey : apiKeyNames) {
-                IdentifierToken fieldName = createIdentifierToken(escapeIdentifier(apiKey.trim()));
+                IdentifierToken fieldName = createIdentifierToken('"' + apiKey.trim() + '"');
                 Token colon = createToken(COLON_TOKEN);
                 FieldAccessExpressionNode fieldExpr = createFieldAccessExpressionNode(
                         createSimpleNameReferenceNode(createIdentifierToken("self")), createToken(DOT_TOKEN),
                         createSimpleNameReferenceNode(createIdentifierToken("apiKeys")));
                 SimpleNameReferenceNode valueExpr = createSimpleNameReferenceNode(
-                        createIdentifierToken("\"" + apiKey + "\""));
+                        createIdentifierToken('"' + apiKey + '"'));
                 SpecificFieldNode specificFieldNode;
                 SeparatedNodeList<ExpressionNode> expressions = createSeparatedNodeList(valueExpr);
                 IndexedExpressionNode apiKeyExpr = createIndexedExpressionNode(fieldExpr,

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
@@ -149,7 +149,6 @@ public class FunctionSignatureGenerator {
         ReturnTypeDescriptorNode returnTypeDescriptorNode = createReturnTypeDescriptorNode(createToken(RETURNS_KEYWORD),
                 createEmptyNodeList(), createBuiltinSimpleNameReferenceNode(null,
                         createIdentifierToken(returnType)));
-
         return createFunctionSignatureNode(createToken(OPEN_PAREN_TOKEN), parameters, createToken(CLOSE_PAREN_TOKEN),
                 returnTypeDescriptorNode);
     }

--- a/openapi-cli/src/test/resources/expected_gen/generate_client.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client.bal
@@ -9,7 +9,7 @@ public isolated client class Client {
     # + clientConfig - Client configuration details
     # + serviceUrl - Connector server URL
     # + return - An error at the failure of client initialization
-    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.openapi.io/v1") returns error? {
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
     }

--- a/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
@@ -11,7 +11,7 @@ public isolated client class Client {
     # + clientConfig - Client configuration details
     # + serviceUrl - Connector server URL
     # + return - An error at the failure of client initialization
-    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.openapi.io/v1") returns error? {
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
     }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns WeatherForecast|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         map<any> headerValues = {"exclude": exclude, "units": units};
         map<string|string[]> accHeaders = getMapForHeaders(headerValues);

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
@@ -26,7 +26,7 @@ public isolated client class Client {
     # + return - Expected response to a valid request
     remote isolated function showPetById(string xRequestId, string[] xRequestClient) returns http:Response|error {
         string  path = string `/pets`;
-        map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, 'X\-API\-KEY: self.apiKeys["X-API-KEY"]};
+        map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-API-KEY": self.apiKeys["X-API-KEY"]};
         map<string|string[]> accHeaders = getMapForHeaders(headerValues);
         http:Response response  = check self.clientEp-> get(path, accHeaders, targetType=http:Response);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
@@ -24,7 +24,7 @@ public isolated client class Client {
     # + return - Expected response to a valid request
     remote isolated function showPetById() returns http:Response|error {
         string  path = string `/pets`;
-        map<any> headerValues = {'X\-API\-KEY: self.apiKeys["X-API-KEY"]};
+        map<any> headerValues = {"X-API-KEY": self.apiKeys["X-API-KEY"]};
         map<string|string[]> accHeaders = getMapForHeaders(headerValues);
         http:Response response = check self.clientEp-> get(path, accHeaders, targetType=http:Response);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = ()) returns WeatherForecast|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         WeatherForecast response = check self.clientEp-> get(path, targetType = WeatherForecast);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns WeatherForecast|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         WeatherForecast response = check self.clientEp-> get(path, targetType = WeatherForecast);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} Latitude lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns json|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         json response = check self.clientEp-> get(path, targetType = json);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = ()) returns WeatherForecast|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         WeatherForecast response = check self.clientEp-> get(path, targetType = WeatherForecast);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
@@ -9,7 +9,7 @@ public isolated client class Client {
     # + clientConfig - Client configuration details
     # + serviceUrl - Connector server URL
     # + return -  An error at the failure of client initialization
-    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.openapi.io/v1") returns error? {
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
     }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
@@ -9,7 +9,7 @@ public isolated client class Client {
     # + clientConfig - Client configuration details
     # + serviceUrl - Connector server URL
     # + return -  An error at the failure of client initialization
-    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.openapi.io/v1") returns error? {
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
     }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
@@ -8,7 +8,7 @@ public isolated client class Client {
     # + clientConfig - Client configuration details
     # + serviceUrl - Connector server URL
     # + return -  An error at the failure of client initialization
-    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.openapi.io/v1") returns error? {
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
     }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
@@ -37,7 +37,7 @@ public isolated client class Client {
     @display {label: "Current Weather"}
     remote isolated function getCurretWeatherData(@display {label: "CityName or StateCode or CountryCode"} string? q = (), @display {label: "City Id"} string? id = (), @display {label: "Latitude"} string? lat = (), @display {label: "Longitude"} string? lon = (), @display {label: "Zip Code"} string? zip = (), @display {label: "Units"} string units = "imperial", @display {label: "Language"} string lang = "en", @display {label: "Mode"} string mode = "json") returns CurrentWeatherData|error {
         string  path = string `/weather`;
-        map<anydata> queryParam = {"q": q, "id": id, "lat": lat, "lon": lon, "zip": zip, "units": units, "lang": lang, "mode": mode, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"q": q, "id": id, "lat": lat, "lon": lon, "zip": zip, "units": units, "lang": lang, "mode": mode, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         CurrentWeatherData response = check self.clientEp-> get(path, targetType = CurrentWeatherData);
         return response;
@@ -53,7 +53,7 @@ public isolated client class Client {
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} string? units = (), @display {label: "Language"} string? lang = ()) returns WeatherForecast|error {
         string  path = string `/onecall`;
-        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "lang": lang, appid: self.apiKeys["appid"]};
+        map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "lang": lang, "appid": self.apiKeys["appid"]};
         path = path + check getPathForQueryParam(queryParam);
         WeatherForecast response = check self.clientEp-> get(path, targetType = WeatherForecast);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
@@ -29,7 +29,7 @@ public isolated client class Client {
     # + return - An array of products
     remote isolated function  products(float latitude, float longitude) returns Product[]|error {
         string  path = string `/products`;
-        map<anydata> queryParam = {"latitude": latitude, "longitude": longitude, server_token: self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"latitude": latitude, "longitude": longitude, "server_token": self.apiKeys["server_token"]};
         path = path + check getPathForQueryParam(queryParam);
         Product[] response = check self.clientEp-> get(path, targetType = ProductArr);
         return response;
@@ -43,7 +43,7 @@ public isolated client class Client {
     # + return - An array of price estimates by product
     remote isolated function  price(float startLatitude, float startLongitude, float endLatitude, float endLongitude) returns PriceEstimate[]|error {
         string  path = string `/estimates/price`;
-        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude, server_token: self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude, "server_token": self.apiKeys["server_token"]};
         path = path + check getPathForQueryParam(queryParam);
         PriceEstimate[] response = check self.clientEp-> get(path, targetType = PriceEstimateArr);
         return response;
@@ -57,7 +57,7 @@ public isolated client class Client {
     # + return - An array of products
     remote isolated function  time(float startLatitude, float startLongitude, string? customerUuid = (), string? productId = ()) returns Product[]|error {
         string  path = string `/estimates/time`;
-        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId, server_token: self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId, "server_token": self.apiKeys["server_token"]};
         path = path + check getPathForQueryParam(queryParam);
         Product[] response = check self.clientEp-> get(path, targetType = ProductArr);
         return response;
@@ -67,7 +67,7 @@ public isolated client class Client {
     # + return - Profile information for a user
     remote isolated function  me() returns Profile|error {
         string  path = string `/me`;
-        map<anydata> queryParam = {server_token: self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"server_token": self.apiKeys["server_token"]};
         path = path + check getPathForQueryParam(queryParam);
         Profile response = check self.clientEp-> get(path, targetType = Profile);
         return response;
@@ -79,7 +79,7 @@ public isolated client class Client {
     # + return - History information for the given user
     remote isolated function  history(int? offset = (), int? 'limit = ()) returns Activities|error {
         string  path = string `/history`;
-        map<anydata> queryParam = {"offset": offset, "limit": 'limit, server_token: self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"offset": offset, "limit": 'limit, "server_token": self.apiKeys["server_token"]};
         path = path + check getPathForQueryParam(queryParam);
         Activities response = check self.clientEp-> get(path, targetType = Activities);
         return response;


### PR DESCRIPTION
## Purpose
$subject
> Select `https` server URL when multiple URLs given - Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/458
> Update header map api key names to a string literal - Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/459
> Remove extra spaces between parameter type and name in util functions - Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/453

## Goals
> Enable users to access the most secured API endpoint
> Increase the cleanness of the generated code. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11
> Ballerina Swan Lake Beta 2