### PR TITLE
Bug fix for mismatching configurable variable names in tests

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -132,7 +132,8 @@ public class GeneratorConstants {
     public static final String API_KEYS_CONFIG = "ApiKeysConfig";
     public static final String API_KEY_CONFIG_PARAM = "apiKeyConfig";
     public static final String API_KEY_CONFIG_RECORD_FIELD = "apiKeys";
-    public static final String AUTH_CONFIG_FILED_NAME = "auth";
+    public static final String AUTH = "auth";
+    public static final String AUTH_CONFIG = "authConfig";
     public static final String BASIC = "basic";
     public static final String BEARER = "bearer";
     public static final String REFRESH_TOKEN = "refresh_token";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
@@ -127,7 +127,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.API_KEY;
 import static io.ballerina.openapi.generators.GeneratorConstants.API_KEYS_CONFIG;
 import static io.ballerina.openapi.generators.GeneratorConstants.API_KEY_CONFIG_PARAM;
 import static io.ballerina.openapi.generators.GeneratorConstants.API_KEY_CONFIG_RECORD_FIELD;
-import static io.ballerina.openapi.generators.GeneratorConstants.AUTH_CONFIG_FILED_NAME;
+import static io.ballerina.openapi.generators.GeneratorConstants.AUTH;
 import static io.ballerina.openapi.generators.GeneratorConstants.AuthConfigTypes;
 import static io.ballerina.openapi.generators.GeneratorConstants.BASIC;
 import static io.ballerina.openapi.generators.GeneratorConstants.BEARER;
@@ -502,7 +502,7 @@ public class BallerinaAuthConfigGenerator {
         // add auth field
         MetadataNode authMetadataNode = getMetadataNode("Configurations related to client authentication");
         IdentifierToken authFieldName = AbstractNodeFactory.createIdentifierToken(escapeIdentifier(
-                AUTH_CONFIG_FILED_NAME));
+                AUTH));
         TypeDescriptorNode authFieldTypeNode =
                 createSimpleNameReferenceNode(createIdentifierToken(getAuthFieldTypeName()));
         RecordFieldNode authFieldNode = NodeFactory.createRecordFieldNode(authMetadataNode, null,

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaTestGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaTestGenerator.java
@@ -258,7 +258,7 @@ public class BallerinaTestGenerator {
                 bindingPattern);
         NodeList<Token> nodeList = createEmptyNodeList();
         ExpressionNode expressionNode = createRequiredExpressionNode(createIdentifierToken(String.format("{%s : %s}",
-                GeneratorConstants.AUTH_CONFIG_FILED_NAME, GeneratorConstants.AUTH_CONFIG_FILED_NAME)));
+                GeneratorConstants.AUTH, GeneratorConstants.AUTH_CONFIG)));
         return createModuleVariableDeclarationNode(metadataNode, null, nodeList, typedBindingPatternNode,
                 createToken(EQUAL_TOKEN), expressionNode, createToken(SEMICOLON_TOKEN));
     }
@@ -281,7 +281,7 @@ public class BallerinaTestGenerator {
         CaptureBindingPatternNode bindingPattern;
         if (isHttpOrOAuth) {
             bindingPattern = createCaptureBindingPatternNode(
-                    createIdentifierToken(GeneratorConstants.AUTH_CONFIG_FILED_NAME));
+                    createIdentifierToken(GeneratorConstants.AUTH_CONFIG));
         } else {
             bindingPattern = createCaptureBindingPatternNode(
                     createIdentifierToken(GeneratorConstants.API_KEY_CONFIG_PARAM));


### PR DESCRIPTION
## Purpose
> $subject

#### Bug
Generated test.bal file 
```
import ballerina/test;
import ballerina/http;

configurable http:BearerTokenConfig & readonly auth = ?;
ClientConfig clientConfig = {auth : auth};
Client baseClient = check new Client(clientConfig);

@test:Config {}
isolated function  testGetAccountPersons() {
}
```

Generated Config.toml file :

```
[authConfig]
token = "<Enter your token here>"
```

`Config.toml` file has `authConfig` record but `test.bal` file search for `auth` record. Results in error

```
error: value not provided for required configurable variable 'auth'
        at aneesha/stripe:0.1.0(tests/test.bal:4)
warning: [Config.toml:(1:1,2:46)] unused configuration value 'authConfig'
```

#### Fix

Change `test.bal`'s configurable variable name to `authConfig`

```
import ballerina/test;
import ballerina/http;

configurable http:BearerTokenConfig & readonly authConfig = ?;
ClientConfig clientConfig = {auth : authConfig};
Client baseClient = check new Client(clientConfig);

@test:Config {}
isolated function  testGetAccountPersons() {
}
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
