### PR TITLE
[Client] Add implementation to check security section when providing authentication via API key

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
@@ -60,6 +60,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -146,8 +147,8 @@ import static io.ballerina.openapi.generators.GeneratorUtils.escapeIdentifier;
  * This class is used to generate authentication related nodes of the ballerina connector client syntax tree.
  */
 public class BallerinaAuthConfigGenerator {
-    private final List<String> headerApiKeyNameList = new ArrayList<>();
-    private final List<String> queryApiKeyNameList = new ArrayList<>();
+    private final Map<String, String> headerApiKeyNameList = new HashMap<>();
+    private final Map<String, String> queryApiKeyNameList = new HashMap<>();
     private boolean isAPIKey = false;
     private boolean isHttpOROAuth = false;
     private final Set<String> authTypes = new LinkedHashSet<>();
@@ -183,7 +184,7 @@ public class BallerinaAuthConfigGenerator {
      *
      * @return {@link List<String>}    API key name list
      */
-    public List<String> getQueryApiKeyNameList() {
+    public Map<String, String> getQueryApiKeyNameList() {
         return queryApiKeyNameList;
     }
 
@@ -192,7 +193,7 @@ public class BallerinaAuthConfigGenerator {
      *
      * @return {@link List<String>}    API key name list
      */
-    public List<String> getHeaderApiKeyNameList() {
+    public Map<String, String> getHeaderApiKeyNameList() {
         return headerApiKeyNameList;
     }
 
@@ -756,10 +757,10 @@ public class BallerinaAuthConfigGenerator {
                         setApiKeyDescription(schemaValue);
                         switch (apiKeyType) {
                             case "query":
-                                queryApiKeyNameList.add(schemaValue.getName());
+                                queryApiKeyNameList.put(securitySchemeEntry.getKey(), schemaValue.getName());
                                 break;
                             case "header":
-                                headerApiKeyNameList.add(schemaValue.getName());
+                                headerApiKeyNameList.put(securitySchemeEntry.getKey(), schemaValue.getName());
                                 break;
                             default:
                                 break;

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -52,9 +52,11 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -203,6 +205,23 @@ public class FunctionBodyGenerator {
     private void handleParameterSchemaInOperation(Map.Entry<PathItem.HttpMethod, Operation> operation,
                                                   List<StatementNode> statementsList) {
 
+        List<String> queryApiKeyNameList = new ArrayList<>();
+        List<String> headerApiKeyNameList = new ArrayList<>();
+
+        Set<String> securitySchemesAvailable = getSecurityRequirementForOperation(operation.getValue());
+
+        if (securitySchemesAvailable.size() > 0) {
+            Map<String, String> queryApiKeyMap = ballerinaAuthConfigGenerator.getQueryApiKeyNameList();
+            Map<String, String> headerApiKeyMap = ballerinaAuthConfigGenerator.getHeaderApiKeyNameList();
+            for (String schemaName : securitySchemesAvailable) {
+                if (queryApiKeyMap.containsKey(schemaName)) {
+                    queryApiKeyNameList.add(queryApiKeyMap.get(schemaName));
+                } else if (headerApiKeyMap.containsKey(schemaName)) {
+                    headerApiKeyNameList.add(headerApiKeyMap.get(schemaName));
+                }
+            }
+        }
+
         if (operation.getValue().getParameters() != null) {
             List<Parameter> parameters = operation.getValue().getParameters();
             List<Parameter> queryParameters = new ArrayList<>();
@@ -214,9 +233,6 @@ public class FunctionBodyGenerator {
                     headerParameters.add(parameter);
                 }
             }
-
-            List<String> queryApiKeyNameList = ballerinaAuthConfigGenerator.getQueryApiKeyNameList();
-            List<String> headerApiKeyNameList = ballerinaAuthConfigGenerator.getHeaderApiKeyNameList();
 
             if (!queryParameters.isEmpty() || !queryApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(queryParameters, "map<anydata>",
@@ -236,8 +252,6 @@ public class FunctionBodyGenerator {
                 isHeader = true;
             }
         } else {
-            List<String> queryApiKeyNameList = ballerinaAuthConfigGenerator.getQueryApiKeyNameList();
-            List<String> headerApiKeyNameList = ballerinaAuthConfigGenerator.getHeaderApiKeyNameList();
 
             if (!queryApiKeyNameList.isEmpty()) {
                 statementsList.add(getMapForParameters(new ArrayList<>(), "map<anydata>",
@@ -257,6 +271,28 @@ public class FunctionBodyGenerator {
             }
 
         }
+    }
+
+    /**
+     * Provides the list of security schemes available for the given operation.
+     * @param operation     Current operation
+     * @return              Security schemes that can be used to authorize the given operation
+     */
+    private Set<String> getSecurityRequirementForOperation(Operation operation) {
+        Set<String> securitySchemasAvailable = new LinkedHashSet<>();
+        List<SecurityRequirement> securityRequirements = new ArrayList<>();
+        if (operation.getSecurity() != null) {
+            securityRequirements = operation.getSecurity();
+        } else if (openAPI.getSecurity() != null) {
+            securityRequirements = openAPI.getSecurity();
+        }
+
+        if (securityRequirements.size() > 0) {
+            for (SecurityRequirement requirement: securityRequirements) {
+                securitySchemasAvailable.addAll(requirement.keySet());
+            }
+        }
+        return securitySchemasAvailable;
     }
 
     /**

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
@@ -45,7 +45,7 @@ public isolated client class Client {
     # + return - An array of price estimates by product
     remote isolated function getPrice(float startLatitude, float startLongitude, float endLatitude, float endLongitude) returns PriceEstimate[]|error {
         string  path = string `/estimates/price`;
-        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude, "server_token": self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude};
         path = path + check getPathForQueryParam(queryParam);
         PriceEstimate[] response = check self.clientEp-> get(path, targetType = PriceEstimateArr);
         return response;
@@ -59,7 +59,7 @@ public isolated client class Client {
     # + return - An array of products
     remote isolated function getTimeEstimates(float startLatitude, float startLongitude, string? customerUuid = (), string? productId = ()) returns Product[]|error {
         string  path = string `/estimates/time`;
-        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId, "server_token": self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId};
         path = path + check getPathForQueryParam(queryParam);
         Product[] response = check self.clientEp-> get(path, targetType = ProductArr);
         return response;
@@ -69,8 +69,6 @@ public isolated client class Client {
     # + return - Profile information for a user
     remote isolated function getUserProfile() returns Profile|error {
         string  path = string `/me`;
-        map<anydata> queryParam = {"server_token": self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
         Profile response = check self.clientEp-> get(path, targetType = Profile);
         return response;
     }
@@ -81,7 +79,7 @@ public isolated client class Client {
     # + return - History information for the given user
     remote isolated function getUserActivity(int? offset = (), int? 'limit = ()) returns Activities|error {
         string  path = string `/history`;
-        map<anydata> queryParam = {"offset": offset, "limit": 'limit, "server_token": self.apiKeys["server_token"]};
+        map<anydata> queryParam = {"offset": offset, "limit": 'limit};
         path = path + check getPathForQueryParam(queryParam);
         Activities response = check self.clientEp-> get(path, targetType = Activities);
         return response;


### PR DESCRIPTION
## Purpose
> $subject
> Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/499

## Goals 
When providing authentication via API keys, consider the `security schemes` configured in root level and operation level security sections. 

## User stories
#### Scenario 1 : Relevant API key security schema has been specified only in the root level.
**Sample OpenAPI definition**
 ```
openapi: 3.0.0
info:
  description: "Client endpoint for the given API"
  license:
    name: Creative Commons
    url: https://creativecommons.org/licenses/by/4.0/legalcode
  title: Api2Pdf - PDF Generation, Powered by AWS Lambda
  version: 1.0.0
security:
  - HeaderApiKey: []
paths:
  ....
components: 
  securitySchemes:
      HeaderApiKey:
        in: header
        name: Authorization
        type: apiKey
      QueryApiKey:
        in: query
        name: apikey
        type: apiKey
````
**Solution** : Configure only `HeaderApiKey` in each operation
```
    remote isolated function chromeFromUrlGET(string url, string? output = ()) returns ApiResponseSuccess|error {
        string  path = string `/chrome/url`;
        map<anydata> queryParam = {"url": url, "output": output};
        path = path + check getPathForQueryParam(queryParam);
        map<any> headerValues = {"Authorization": self.apiKeys["Authorization"]};
        map<string|string[]> accHeaders = getMapForHeaders(headerValues);
        ApiResponseSuccess response = check self.clientEp-> get(path, accHeaders, targetType = ApiResponseSuccess);
        return response;
    }
    remote isolated function chromeFromUrlPost(ChromeUrlToPdfRequest payload) returns ApiResponseSuccess|error {
        string  path = string `/chrome/url`;
        map<any> headerValues = {"Authorization": self.apiKeys["Authorization"]};
        map<string|string[]> accHeaders = getMapForHeaders(headerValues);
        http:Request request = new;
        json jsonBody = check payload.cloneWithType(json);
        request.setPayload(jsonBody);
        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = accHeaders, targetType=ApiResponseSuccess);
        return response;
    }
```
#### Scenario 2 : Relevant API key security schema has been specified individually in each operation. 
**Sample OpenAPI definition**
 ```
paths:
  /chrome/url:
    get:
      operationId: chromeFromUrlGET
      security:
        - QueryApiKey: []
      .......
    post:
      operationId: chromeFromUrlPost
      security:
        - HeaderApiKey: []
      .......
  ....
components: 
  securitySchemes:
      HeaderApiKey:
        in: header
        name: Authorization
        type: apiKey
      QueryApiKey:
        in: query
        name: apikey
        type: apiKey
````
**Solution** : Configure only the specific security schema mentioned in each operation
```
    remote isolated function chromeFromUrlGET(string url, string? output = ()) returns ApiResponseSuccess|error {
        string  path = string `/chrome/url`;
        map<anydata> queryParam = {"url": url, "output": output, "apikey": self.apiKeys["apikey"]};
        path = path + check getPathForQueryParam(queryParam);
        ApiResponseSuccess response = check self.clientEp-> get(path, targetType = ApiResponseSuccess);
        return response;
    }
    remote isolated function chromeFromUrlPost(ChromeUrlToPdfRequest payload) returns ApiResponseSuccess|error {
        string  path = string `/chrome/url`;
        map<any> headerValues = {"Authorization": self.apiKeys["Authorization"]};
        map<string|string[]> accHeaders = getMapForHeaders(headerValues);
        http:Request request = new;
        json jsonBody = check payload.cloneWithType(json);
        request.setPayload(jsonBody);
        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = accHeaders, targetType=ApiResponseSuccess);
        return response;
    }
```

#### Scenario 3 : Relevant API key security schema has been specified individually in both root level and operation level. Security schema specified in root level will be overridden by the operation level security schema.  
**Sample OpenAPI definition**
 ```
openapi: 3.0.0
info:
  description: "Client endpoint for the given API"
  license:
    name: Creative Commons
    url: https://creativecommons.org/licenses/by/4.0/legalcode
  title: Api2Pdf - PDF Generation, Powered by AWS Lambda
  version: 1.0.0
security:
  - HeaderApiKey: []
paths:
  /chrome/url:
    get:
      operationId: chromeFromUrlGET
      security:
        - QueryApiKey: []
      .......
  ....
components: 
  securitySchemes:
      HeaderApiKey:
        in: header
        name: Authorization
        type: apiKey
      QueryApiKey:
        in: query
        name: apikey
        type: apiKey
````
**Solution** : Configure only the specific security schema mentioned in operation level and ignore the root level security schema. 
```
    remote isolated function chromeFromUrlGET(string url, string? output = ()) returns ApiResponseSuccess|error {
        string  path = string `/chrome/url`;
        map<anydata> queryParam = {"url": url, "output": output, "apikey": self.apiKeys["apikey"]};
        path = path + check getPathForQueryParam(queryParam);
        ApiResponseSuccess response = check self.clientEp-> get(path, targetType = ApiResponseSuccess);
        return response;
    }
```



## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Test environment
> Java JDK 11