### PR TITLE
[Client] Remove `ballerina/lang.'string` import in client generation 

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -245,10 +245,7 @@ public class BallerinaClientGenerator {
         if (isQuery) {
             ImportDeclarationNode url = GeneratorUtils.getImportDeclarationNode(
                     GeneratorConstants.BALLERINA, "url");
-            ImportDeclarationNode string = GeneratorUtils.getImportDeclarationNode(
-                    GeneratorConstants.BALLERINA, "lang.'string");
             imports.add(url);
-            imports.add(string);
             NodeList<ImportDeclarationNode> importsList = createNodeList(imports);
             FunctionDefinitionNode queryParamFunction = getQueryParamPath();
 

--- a/openapi-cli/src/test/resources/expected_gen/generate_client.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 public isolated client class Client {
     final http:Client clientEp;

--- a/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
@@ -2,7 +2,6 @@
 
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 public isolated client class Client {
     final http:Client clientEp;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 public isolated client class Client {
     public final http:Client clientEp;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city.
 @display {label: "Open Weather Client"}

--- a/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 public isolated client class Client {
     public final http:Client clientEp;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 public type ApplicationPropertyArr ApplicationProperty[];
 

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
@@ -1,6 +1,5 @@
 import  ballerina/http;
 import  ballerina/url;
-import  ballerina/lang.'string;
 
 # Provides API key configurations needed when communicating with a remote HTTP endpoint.
 public type ApiKeysConfig record {|


### PR DESCRIPTION
## Purpose
> Remove import ballerina/lang.'string since the packages under `ballerina/lang` automatically get loaded

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.