### PR TITLE
[Client] Remove unnecessary request initialization in delete operations

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -298,8 +298,7 @@ public class FunctionBodyGenerator {
         String clientCallStatement;
 
         // This condition for several methods.
-        boolean isMethod = method.equals(POST) || method.equals(PUT) || method.equals(PATCH) || method.equals(
-                DELETE) || method.equals(EXECUTE);
+        boolean isMethod = method.equals(POST) || method.equals(PUT) || method.equals(PATCH) || method.equals(EXECUTE);
         if (isHeader) {
             if (isMethod) {
                 ExpressionStatementNode requestStatementNode = generatorUtils.getSimpleExpressionStatementNode(

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -83,8 +83,10 @@ public class FunctionBodyNodeTests {
                         "map<any>headerValues={\"x-ms-client-request-id\":xMsClientRequestId," +
                         "\"x-ms-date\":xMsDate,\"x-ms-version\":xMsVersion};map<string|string[]> " +
                         "accHeaders = getMapForHeaders(headerValues);" +
-                        "http:Responseresponse=check self.clientEp-> head(path, accHeaders);returnresponse;}"}
-
+                        "http:Responseresponse=check self.clientEp-> head(path, accHeaders);returnresponse;}"},
+                {"diagnostic_files/operation_delete.yaml", "/pets/{petId}", "{string  path = string `/pets/${petId}`;" +
+                        "http:Response response = check self.clientEp-> delete(path, targetType = http:Response);" +
+                        "return response;}"}
         };
     }
     //TODO:Different mediaType

--- a/openapi-cli/src/test/resources/generators/client/diagnostic_files/operation_delete.yaml
+++ b/openapi-cli/src/test/resources/generators/client/diagnostic_files/operation_delete.yaml
@@ -1,0 +1,96 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets/{petId}:
+    delete:
+      summary: Delete pet
+      operationId: deletePetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "204":
+          description: |-
+            **HTTP status code:** `204` OK
+  /action:
+    x-MULTI:
+      operationId: getAction
+      responses:
+        '200':
+          description: Successful
+          examples:
+            application/json: Ok
+      x-METHODS:
+        - HEAD
+        - OPTIONS
+        - PATCH
+        - DELETE
+        - POST
+        - PUT
+        - GET
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
## Purpose
> Bug fix
> $subject
Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/480

## Goals
Sample generated code for http DELETE operations with no request body 

```ballerina
  remote isolated function deletePetById(string petId) returns http:Response|error {
        string  path = string `/pets/${petId}`;
        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
        return response;
    }
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> Ubuntu 20.04
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.