### PR TITLE
[Client] Add implementation to generate types.bal only when schemes are given

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
@@ -457,8 +457,10 @@ public class CodeGenerator {
             // Remove unused records and enums when generating the client by the tags given.
             schemaContent = modifySchemaContent(schemaSyntaxTree, mainContent, schemaContent);
         }
-        sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.MODEL_SRC, srcPackage,  TYPE_FILE_NAME,
-                schemaContent));
+        if (!schemaContent.isBlank()) {
+            sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.MODEL_SRC, srcPackage,  TYPE_FILE_NAME,
+                    schemaContent));
+        }
 
         // Generate test boilerplate code for test cases
         BallerinaTestGenerator ballerinaTestGenerator = new BallerinaTestGenerator(ballerinaClientGenerator);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -358,6 +358,26 @@ public class CodeGeneratorTest {
         }
     }
 
+    @Test(description = "Test code generation when no schemas given")
+    public void testCodeGenerationWithoutSchemas() {
+        final String clientName = "openapipetstore";
+        String definitionPath = RES_DIR.resolve("no_schema.yaml").toString();
+        CodeGenerator generator = new CodeGenerator();
+        try {
+            generator.generateClient(definitionPath, clientName, resourcePath.toString(), filter, false);
+            if (Files.exists(resourcePath.resolve("client.bal")) &&
+                    Files.notExists(resourcePath.resolve("types.bal"))) {
+                Assert.assertTrue(true);
+            } else {
+                Assert.fail("Empty types.bal file has been generated");
+            }
+        } catch (IOException | BallerinaOpenApiException | FormatterException e) {
+            Assert.fail("Error while generating the client. " + e.getMessage());
+        } finally {
+            deleteGeneratedFiles("client.bal");
+        }
+    }
+
     @Test(description = "Functionality tests when invalid OpenAPI definition is given",
             expectedExceptions = BallerinaOpenApiException.class,
             expectedExceptionsMessageRegExp = "OpenAPI file has errors: .*")

--- a/openapi-cli/src/test/resources/no_schema.yaml
+++ b/openapi-cli/src/test/resources/no_schema.yaml
@@ -1,0 +1,68 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema: {}
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response


### PR DESCRIPTION
## Purpose
> Bug fix 
> $subject
Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/426

## Goals
> Generated types.bal file only when at least one type is available

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yesno - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11, 
 > Ubuntu 20.04 LTS