### PR TITLE
[Client] Provide support for inline two dimensional array in response schemes

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
@@ -71,7 +71,8 @@ public class BallerinaDiagnosticTests {
                 {"openapi_display_annotation.yaml"},
                 {"header_parameter.yaml"},
                 {"petstore_post.yaml"},
-                {"petstore_with_oneOf_response.yaml"}
+                {"petstore_with_oneOf_response.yaml"},
+                {"response_nested_array.yaml"}
         };
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -79,6 +79,28 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(returnTypeNode.type().toString(), "Product[]|error");
     }
 
+    @Test(description = "Test for generate function signature with nested array return type")
+    public void getFunctionSignatureForNestedArrayResponse() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RESDIR.resolve("swagger/response_nested_array.yaml"));
+        FunctionSignatureGenerator functionSignatureGenerator = new FunctionSignatureGenerator(openAPI,
+                new BallerinaSchemaGenerator(openAPI), new ArrayList<>());
+        FunctionSignatureNode signature = functionSignatureGenerator.getFunctionSignatureNode(openAPI.getPaths()
+                .get("/timestags").getGet(), new ArrayList<>());
+        ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
+        Assert.assertEquals(returnTypeNode.type().toString(), "string[][]|error");
+    }
+
+    @Test(description = "Test for generate function signature with string array return type")
+    public void getFunctionSignatureForStringArrayResponse() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RESDIR.resolve("swagger/response_string_array.yaml"));
+        FunctionSignatureGenerator functionSignatureGenerator = new FunctionSignatureGenerator(openAPI,
+                new BallerinaSchemaGenerator(openAPI), new ArrayList<>());
+        FunctionSignatureNode signature = functionSignatureGenerator.getFunctionSignatureNode(openAPI.getPaths()
+                .get("/timestags").getGet(), new ArrayList<>());
+        ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
+        Assert.assertEquals(returnTypeNode.type().toString(), "string[]|error");
+    }
+
     @AfterTest
     private void deleteGeneratedFiles() {
         try {

--- a/openapi-cli/src/test/resources/generators/client/diagnostic_files/response_nested_array.yaml
+++ b/openapi-cli/src/test/resources/generators/client/diagnostic_files/response_nested_array.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.0
+servers:
+  - url: https://api.nytimes.com/svc/suggest/v1
+info:
+  description: With the TimesTags API, you can mine the riches of the New York Times tag set. The TimesTags service matches your query to the controlled vocabularies that fuel NYTimes.com metadata. You supply a string of characters, and the service returns a ranked list of suggested terms.
+  termsOfService: http://developer.nytimes.com/tou
+  title: TimesTags API
+  version: 1.0.0
+security:
+  - apikey: []
+paths:
+  /timestags:
+    get:
+      operationId: getTimesTags
+      parameters:
+        - description: Your search query
+          in: query
+          name: query
+          required: true
+          schema:
+            type: string
+        - description: Add filters
+          in: query
+          name: filter
+          required: false
+          schema:
+            enum:
+              - Des
+              - Geo
+              - Org
+              - Per
+            type: string
+        - description: Sets the maximum number of results
+          in: query
+          name: max
+          required: false
+          schema:
+            default: 10
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  items:
+                    type: string
+                  type: array
+                type: array
+          description: An array of tags
+components:
+  securitySchemes:
+    apikey:
+      in: query
+      name: api-key
+      type: apiKey

--- a/openapi-cli/src/test/resources/generators/client/swagger/response_nested_array.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/response_nested_array.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.0
+servers:
+  - url: https://api.nytimes.com/svc/suggest/v1
+info:
+  description: With the TimesTags API, you can mine the riches of the New York Times tag set. The TimesTags service matches your query to the controlled vocabularies that fuel NYTimes.com metadata. You supply a string of characters, and the service returns a ranked list of suggested terms.
+  termsOfService: http://developer.nytimes.com/tou
+  title: TimesTags API
+  version: 1.0.0
+security:
+  - apikey: []
+paths:
+  /timestags:
+    get:
+      operationId: getTimesTags
+      parameters:
+        - description: Your search query
+          in: query
+          name: query
+          required: true
+          schema:
+            type: string
+        - description: Add filters
+          in: query
+          name: filter
+          required: false
+          schema:
+            enum:
+              - Des
+              - Geo
+              - Org
+              - Per
+            type: string
+        - description: Sets the maximum number of results
+          in: query
+          name: max
+          required: false
+          schema:
+            default: 10
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  items:
+                    type: string
+                  type: array
+                type: array
+          description: An array of tags
+components:
+  securitySchemes:
+    apikey:
+      in: query
+      name: api-key
+      type: apiKey

--- a/openapi-cli/src/test/resources/generators/client/swagger/response_string_array.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/response_string_array.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+servers:
+  - url: https://api.nytimes.com/svc/suggest/v1
+info:
+  description: With the TimesTags API, you can mine the riches of the New York Times tag set. The TimesTags service matches your query to the controlled vocabularies that fuel NYTimes.com metadata. You supply a string of characters, and the service returns a ranked list of suggested terms.
+  termsOfService: http://developer.nytimes.com/tou
+  title: TimesTags API
+  version: 1.0.0
+security:
+  - apikey: []
+paths:
+  /timestags:
+    get:
+      operationId: getTimesTags
+      parameters:
+        - description: Your search query
+          in: query
+          name: query
+          required: true
+          schema:
+            type: string
+        - description: Add filters
+          in: query
+          name: filter
+          required: false
+          schema:
+            enum:
+              - Des
+              - Geo
+              - Org
+              - Per
+            type: string
+        - description: Sets the maximum number of results
+          in: query
+          name: max
+          required: false
+          schema:
+            default: 10
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: An array of tags
+components:
+  securitySchemes:
+    apikey:
+      in: query
+      name: api-key
+      type: apiKey


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/430

## Goals

**Sample OpenAPI definition with 2D inline array as response schema**
```
responses:
  "200":
    content:
      application/json:
        schema:
          items:
            items:
              type: string
            type: array
          type: array
    description: An array of tags
```

**Solution implemented**
```ballerina
public type StringNestedArr string[][];

remote isolated function getTimesTags(string query, string? filter = (), int max = 10) returns string[][]|error {
    string  path = string `/timestags`;
    map<anydata> queryParam = {"query": query, "filter": filter, "max": max, "api-key": self.apiKeys["api-key"]};
    path = path + check getPathForQueryParam(queryParam);
    string[][] response = check self.clientEp-> get(path, targetType = StringNestedArr);
    return response;
}
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> Ubuntu 20.04
 