### PR TITLE
[Client] Bug fix in record field generation when the type of inline allOf schema in not specified 

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/BallerinaSchemaGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/BallerinaSchemaGenerator.java
@@ -356,7 +356,7 @@ public class BallerinaSchemaGenerator {
             if (allOfSchema.getType() == null && allOfSchema.get$ref() != null) {
                 //Generate typeReferenceNode
                 getAllOfRecordFieldForReference(schemaDoc, recordFieldList, allOfSchema);
-            } else if (allOfSchema instanceof ObjectSchema && (allOfSchema.getProperties() != null)) {
+            } else if (allOfSchema.getProperties() != null) {
                 if (allOfSchema.getDescription() != null) {
                     schemaDoc.addAll(DocCommentsGenerator.createAPIDescriptionDoc(
                             allOfSchema.getDescription(), false));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/AllOfDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/AllOfDataTypeTests.java
@@ -54,4 +54,23 @@ public class AllOfDataTypeTests {
         syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/allOf.bal", syntaxTree);
     }
+
+    @Test(description = "Generate record for allOf schema with array schema")
+    public void generateAllOfWithTypeUnSpecifiedObjectSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/allOfWithNoType.yaml");
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
+        BallerinaSchemaGenerator ballerinaSchemaGenerator = new BallerinaSchemaGenerator(openAPI);
+        syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/allOfWithNoType.bal", syntaxTree);
+    }
+
+    @Test(description = "Generate record for allOf schema with empty object schema")
+    public void generateAllOfWithEmptyObjectSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/allOfWithEmptyObject.yaml");
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
+        BallerinaSchemaGenerator ballerinaSchemaGenerator = new BallerinaSchemaGenerator(openAPI);
+        syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/allOfWithEmptyObject.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithEmptyObject.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithEmptyObject.bal
@@ -1,0 +1,10 @@
+public type Pets Pet[];
+
+public type Error record {
+    int code;
+    string message;
+};
+
+public type Pet record {
+    string[] entries?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithNoType.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithNoType.bal
@@ -1,0 +1,14 @@
+public type Pets Pet[];
+
+public type Error record {
+    int code;
+    string message;
+};
+
+public type Pet record {
+    int id?;
+    string name?;
+    string tag?;
+    string 'type?;
+    string[] entries?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/allOfWithEmptyObject.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/allOfWithEmptyObject.yaml
@@ -1,0 +1,86 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      allOf:
+        - description: "Pet details"
+          type: object
+        - properties:
+            entries:
+              type: array
+              items:
+                type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-cli/src/test/resources/generators/schema/swagger/allOfWithNoType.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/allOfWithNoType.yaml
@@ -1,0 +1,94 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      allOf:
+        - properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+            tag:
+              type: string
+            type:
+              type: string
+        - properties:
+            entries:
+              type: array
+              items:
+                type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
## Purpose
> $subject

In the current connector generation, record fields are not generated in below scenario

```
Pet:
      allOf:
        - properties:
            id:
              type: integer
              format: int64
            name:
              type: string
            tag:
              type: string
            type:
              type: string
        - properties:
            entries:
              type: array
              items:
                type: string
```
The issue is due to not specifying the type in the schemas under allOf schema.  At the times that the type of the schema is not specified but the properties are given, the schema is type: object by default

Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/370

## Goals

In the above scenario. ballerina code should be generated as below. 
```ballerina
public type Pet record {
    int id?;
    string name?;
    string tag?;
    string 'type?;
    string[] entries?;
};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> Ubuntu 20.04