### PR TITLE
[Client] Rename OpenAPI extension names

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/DocCommentsGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/DocCommentsGenerator.java
@@ -56,6 +56,7 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.COMMA_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.DOCUMENTATION_DESCRIPTION;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_LITERAL;
+import static io.ballerina.openapi.generators.GeneratorConstants.X_BALLERINA_DISPLAY;
 
 /**
  * This class util for maintain the API doc comment related functions.
@@ -71,7 +72,7 @@ public class DocCommentsGenerator {
         NodeList<AnnotationNode> annotationNodes = createEmptyNodeList();
         if (extensions != null) {
             for (Map.Entry<String, Object> extension: extensions.entrySet()) {
-                if (extension.getKey().trim().equals("x-display")) {
+                if (extension.getKey().trim().equals(X_BALLERINA_DISPLAY)) {
                     AnnotationNode annotationNode = getAnnotationNode(extension);
                     annotationNodes = createNodeList(annotationNode);
                 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -159,4 +159,9 @@ public class GeneratorConstants {
     public static final String OPTIONS = "options";
     public static final String TRACE = "trace";
 
+    //OpenAPI Ballerina extensions
+    public static final String X_BALLERINA_INIT_DESCRIPTION = "x-ballerina-init-description";
+    public static final String X_BALLERINA_DISPLAY = "x-ballerina-display";
+    public static final String X_BALLERINA_APIKEY_DESCRIPTION = "x-ballerina-apikey-description";
+
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
@@ -141,6 +141,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.OAUTH2;
 import static io.ballerina.openapi.generators.GeneratorConstants.PASSWORD;
 import static io.ballerina.openapi.generators.GeneratorConstants.REFRESH_TOKEN;
 import static io.ballerina.openapi.generators.GeneratorConstants.SSL_FIELD_NAME;
+import static io.ballerina.openapi.generators.GeneratorConstants.X_BALLERINA_APIKEY_DESCRIPTION;
 import static io.ballerina.openapi.generators.GeneratorUtils.escapeIdentifier;
 
 /**
@@ -206,8 +207,8 @@ public class BallerinaAuthConfigGenerator {
         return authTypes;
     }
     /**
-     * Returns the `x-apikey-description` given when the authentication mechanism is API key. This value will be
-     * mapped to connector init function `apiKeyConfig` parameter doc comment.
+     * Returns the `x-ballerina-apikey-description` given when the authentication mechanism is API key.
+     * This value will be mapped to connector init function `apiKeyConfig` parameter doc comment.
      *
      * @return {@link String}   Api key description
      */
@@ -829,7 +830,7 @@ public class BallerinaAuthConfigGenerator {
     /**
      * This method is used set the apiKeyDescription when API key security schema is given.
      *
-     * @param scheme    SecurityScheme to get the value of x-apikey-description extension
+     * @param scheme    SecurityScheme to get the value of x-ballerina-apikey-description extension
      */
     private void setApiKeyDescription(SecurityScheme scheme) {
         apiKeyDescription = "API key configuration detail";
@@ -837,7 +838,7 @@ public class BallerinaAuthConfigGenerator {
             Map<String, Object> extensions = scheme.getExtensions();
             if (!extensions.isEmpty()) {
                 for (Map.Entry<String, Object> extension : extensions.entrySet()) {
-                    if (extension.getKey().trim().equals("x-apikey-description")) {
+                    if (extension.getKey().trim().equals(X_BALLERINA_APIKEY_DESCRIPTION)) {
                         apiKeyDescription = extension.getValue().toString();
                     }
                 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -143,6 +143,8 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RETURNS_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.openapi.generators.GeneratorConstants.HTTP;
+import static io.ballerina.openapi.generators.GeneratorConstants.X_BALLERINA_DISPLAY;
+import static io.ballerina.openapi.generators.GeneratorConstants.X_BALLERINA_INIT_DESCRIPTION;
 
 /**
  * This Util class uses for generating ballerina client file according to given yaml file.
@@ -287,7 +289,7 @@ public class BallerinaClientGenerator {
             Map<String, Object> extensions = openAPI.getInfo().getExtensions();
             if (!extensions.isEmpty()) {
                 for (Map.Entry<String, Object> extension: extensions.entrySet()) {
-                    if (extension.getKey().trim().equals("x-display")) {
+                    if (extension.getKey().trim().equals(X_BALLERINA_DISPLAY)) {
                         metadataNode = DocCommentsGenerator.getMetadataNodeForDisplayAnnotation(extension);
                     }
                 }
@@ -398,7 +400,7 @@ public class BallerinaClientGenerator {
         if (openAPI.getInfo().getExtensions() != null && !openAPI.getInfo().getExtensions().isEmpty()) {
             Map<String, Object> extensions = openAPI.getInfo().getExtensions();
             for (Map.Entry<String, Object> extension: extensions.entrySet()) {
-                if (extension.getKey().trim().equals("x-init-description")) {
+                if (extension.getKey().trim().equals(X_BALLERINA_INIT_DESCRIPTION)) {
                     clientInitDocComment = clientInitDocComment.concat(extension.getValue().toString());
                     break;
                 }
@@ -476,7 +478,7 @@ public class BallerinaClientGenerator {
                     Map<String, Object> extensions = operation.getValue().getExtensions();
                     if (extensions != null) {
                         for (Map.Entry<String, Object> extension : extensions.entrySet()) {
-                            if (extension.getKey().trim().equals("x-display")) {
+                            if (extension.getKey().trim().equals(X_BALLERINA_DISPLAY)) {
                                 metadataNode = DocCommentsGenerator.getMetadataNodeForDisplayAnnotation(extension);
                                 break;
                             }

--- a/openapi-cli/src/test/resources/generators/client/auth/scenarios/api_key/custome_api_key_doc.yaml
+++ b/openapi-cli/src/test/resources/generators/client/auth/scenarios/api_key/custome_api_key_doc.yaml
@@ -317,6 +317,6 @@ components:
     app_id:
       type: apiKey
       description: API key to authorize requests.
-      x-apikey-description: "Provide your API key as `appid`. Eg: `{\"appid\" : \"<API key>\"}`"
+      x-ballerina-apikey-description: "Provide your API key as `appid`. Eg: `{\"appid\" : \"<API key>\"}`"
       name: appid
       in: query

--- a/openapi-cli/src/test/resources/generators/client/diagnostic_files/openapi_display_annotation.yaml
+++ b/openapi-cli/src/test/resources/generators/client/diagnostic_files/openapi_display_annotation.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: "CC Attribution-ShareAlike 4.0 (CC BY-SA 4.0)"
     url: "https://openweathermap.org/price"
-  x-display:
+  x-ballerina-display:
     label: "Current Weather Details"
     iconPath: "Path"
 
@@ -36,7 +36,7 @@ paths:
         - $ref: '#/components/parameters/units'
         - $ref: '#/components/parameters/lang'
         - $ref: '#/components/parameters/mode'
-      x-display:
+      x-ballerina-display:
         label: "Current weather"
       responses:
         200:
@@ -73,7 +73,7 @@ components:
       description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by comma; use ISO 3166 country codes."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "City name"
     id:
       name: id

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/openapi.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/openapi.yaml
@@ -24,7 +24,7 @@ paths:
         - SendEmail
       description: "Send an email to given recipient"
       operationId: sendEmail
-      x-display:
+      x-ballerina-display:
         label: "Send Email"
       requestBody:
         content:
@@ -34,23 +34,23 @@ paths:
                 recipient:
                   type: string
                   description: "The recipient of the mail"
-                  x-display: "Recipient"
+                  x-ballerina-display: "Recipient"
                 subject:
                   type: string
                   description: "The subject of the mail"
-                  x-display:  "Subject"
+                  x-ballerina-display:  "Subject"
                 body:
                   type: string
                   description: "The message body of the mail"
-                  x-display: "Message Body"
+                  x-ballerina-display: "Message Body"
                 cc:
                   type: string
                   description: "The cc recipient of the mail. Optional"
-                  x-display: "Cc"
+                  x-ballerina-display: "Cc"
                 bcc:
                   type: string
                   description: "The bcc recipient of the mail. Optional"
-                  x-display: "Bcc"
+                  x-ballerina-display: "Bcc"
               required:
                 - recipient
                 - subject

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/openapi_weather_api.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/openapi_weather_api.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: "CC Attribution-ShareAlike 4.0 (CC BY-SA 4.0)"
     url: "https://openweathermap.org/price"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -34,7 +34,7 @@ paths:
         - $ref: '#/components/parameters/units'
         - $ref: '#/components/parameters/lang'
         - $ref: '#/components/parameters/mode'
-      x-display:
+      x-ballerina-display:
         label: "Current Weather"
       responses:
         200:
@@ -65,7 +65,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -73,7 +73,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "By using this parameter you can exclude some parts of the weather data from the API response. It should be a comma-delimited list (without spaces)."
           in: query
@@ -87,7 +87,7 @@ paths:
               - 'daily'
               - 'alerts'
             type: string
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: '**Units**. *Example: imperial*. Possible values: `standard`, `metric`, and `imperial`. When you do not use units parameter, format is `standard` by default.'
           in: query
@@ -95,7 +95,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Units
         - description: '**Language**. *Example: en*. You can use lang parameter to get the output in your language. We support the following languages that you can use with the corresponded lang values: Arabic - `ar`, Bulgarian - `bg`, Catalan - `ca`, Czech - `cz`, German - `de`, Greek - `el`, English - `en`, Persian (Farsi) - `fa`, Finnish - `fi`, French - `fr`, Galician - `gl`, Croatian - `hr`, Hungarian - `hu`, Italian - `it`, Japanese - `ja`, Korean - `kr`, Latvian - `la`, Lithuanian - `lt`, Macedonian - `mk`, Dutch - `nl`, Polish - `pl`, Portuguese - `pt`, Romanian - `ro`, Russian - `ru`, Swedish - `se`, Slovak - `sk`, Slovenian - `sl`, Spanish - `es`, Turkish - `tr`, Ukrainian - `ua`, Vietnamese - `vi`, Chinese Simplified - `zh_cn`, Chinese Traditional - `zh_tw`.'
           in: query
@@ -103,9 +103,9 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Language
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:
@@ -144,7 +144,7 @@ components:
       description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by comma; use ISO 3166 country codes."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "CityName or StateCode or CountryCode"
     id:
       name: id
@@ -152,7 +152,7 @@ components:
       description: "**City ID**. *Example: `2172797`*. You can call by city ID. API responds with exact result. The List of city IDs can be downloaded [here](http://bulk.openweathermap.org/sample/). You can include multiple cities in parameter &mdash; just separate them by commas. The limit of locations is 20. *Note: A single ID counts as a one API call. So, if you have city IDs. it's treated as 3 API calls.*"
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "City Id"
     lat:
       name: lat
@@ -160,7 +160,7 @@ components:
       description: "**Latitude**. *Example: 35*. The latitude cordinate of the location of your interest. Must use with `lon`."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "Latitude"
 
     lon:
@@ -169,7 +169,7 @@ components:
       description: "**Longitude**. *Example: 139*. Longitude cordinate of the location of your interest. Must use with `lat`."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "Longitude"
 
     zip:
@@ -178,7 +178,7 @@ components:
       description: "**Zip code**. Search by zip code. *Example: 95050,us*. Please note if country is not specified then the search works for USA as a default."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "Zip Code"
 
     units:
@@ -189,7 +189,7 @@ components:
         type: string
         enum: [standard, metric, imperial]
         default: "imperial"
-      x-display:
+      x-ballerina-display:
         label: "Units"
 
     lang:
@@ -200,7 +200,7 @@ components:
         type: string
         enum: [ar, bg, ca, cz, de, el, en, fa, fi, fr, gl, hr, hu, it, ja, kr, la, lt, mk, nl, pl, pt, ro, ru, se, sk, sl, es, tr, ua, vi, zh_cn, zh_tw]
         default: "en"
-      x-display:
+      x-ballerina-display:
         label: "Language"
 
     mode:
@@ -211,7 +211,7 @@ components:
         type: string
         enum: [json, xml, html]
         default: "json"
-      x-display:
+      x-ballerina-display:
         label: "Mode"
   schemas:
     WeatherForecast:

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/playlist.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/playlist.yaml
@@ -4,7 +4,7 @@ servers:
 info:
   title: Spotify Web API
   version: 0.1.0
-  x-display:
+  x-ballerina-display:
     label: "Spotify Client"
 externalDocs:
   description: Find more info on the official Spotify Web API Reference
@@ -25,7 +25,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-list-of-current-users-playlists
       operationId: getMyPlaylists
-      x-display:
+      x-ballerina-display:
         label: "My Playlists"
       parameters:
         - description: "'The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50.'"
@@ -35,7 +35,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Limit"
         - description: "'The index of the first playlist to return. Default: 0 (the first object). Maximum offset: 100.000. Use with `limit` to get the next set of playlists.'"
           in: query
@@ -44,7 +44,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Offset"
       responses:
         "200":
@@ -69,7 +69,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-playlist
       operationId: getPlaylistById
-      x-display:
+      x-ballerina-display:
         label: "Playlist By Id"
       parameters:
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
@@ -78,7 +78,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
         - description: |-
             An [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or the string `from_token`. Provide this parameter if you want to apply [Track
@@ -89,7 +89,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Market"
         - description: "Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are returned. For example, to get just the playlist''s description and URI: `fields=description,uri`. A dot separator can be used to specify non-reoccurring fields, while parentheses can be used to specify reoccurring fields within objects. For example, to get just the added date and user ID of the adder: `fields=tracks.items(added_at,added_by.id)`. Use multiple parentheses to drill down into nested objects, for example: `fields=tracks.items(track(name,href,album(name,href)))`. Fields can be excluded by prefixing them with an exclamation mark, for example: `fields=tracks.items(track(name,href,album(!name,href)))`"
           in: query
@@ -97,7 +97,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Fields to Return"
         - description: "A comma-separated list of item types that your client supports besides the default `track` type. Valid types are: `track` and `episode`. **Note** : This parameter was introduced to allow existing clients to maintain their current behaviour and might be deprecated in the future. In addition to providing this parameter, make sure that your client properly handles cases of new types in the future by checking against the `type` field of each object."
           in: query
@@ -105,7 +105,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Additional Types"
       responses:
         "200":
@@ -129,7 +129,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-change-playlist-details
       operationId: updatePlaylist
-      x-display:
+      x-ballerina-display:
         label: "Update Playlist"
       parameters:
         - description: "The content type of the request body: `application/json`"
@@ -138,7 +138,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Content Type"
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
           in: path
@@ -146,7 +146,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
       requestBody:
         content:
@@ -178,7 +178,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-playlist-cover
       operationId: getPlaylistCover
-      x-display:
+      x-ballerina-display:
         label: "Playlist Cover"
       parameters:
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
@@ -187,7 +187,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
       responses:
         "200":
@@ -213,7 +213,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-upload-custom-playlist-cover
       operationId: updatePlaylistCover
-      x-display:
+      x-ballerina-display:
         label: "Update Playlist Cover"
       parameters:
         - description: "The content type of the request body: `image/jpeg`"
@@ -222,7 +222,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Content Type"
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
           in: path
@@ -230,7 +230,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
       responses:
         "202":
@@ -255,7 +255,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-playlists-tracks
       operationId: getPlaylistTracks
-      x-display:
+      x-ballerina-display:
         label: "Playlist Tracks"
       parameters:
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
@@ -264,7 +264,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
         - description: |-
             An [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or the string `from_token`. Provide this parameter if you want to apply [Track
@@ -275,7 +275,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Market"
         - description: |-
             Filters for the query: a comma-separated list of the fields to return. If omitted, all fields are returned. For example, to get just the total number of items and the request limit:
@@ -291,7 +291,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Fields to Return"
         - description: "The maximum number of items to return. Default: 100. Minimum: 1. Maximum: 100."
           in: query
@@ -300,7 +300,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Limit"
         - description: "The index of the first item to return. Default: 0 (the first object)."
           in: query
@@ -309,7 +309,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Offset"
         - description: "A comma-separated list of item types that your client supports besides the default `track` type. Valid types are: `track` and `episode`. **Note** : This parameter was introduced to allow existing clients to maintain their current behaviour and might be deprecated in the future. In addition to providing this parameter, make sure that your client properly handles cases of new types in the future by checking against the `type` field of each object."
           in: query
@@ -345,7 +345,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-reorder-or-replace-playlists-tracks
       operationId: reorderOrReplacePlaylistTracks
-      x-display:
+      x-ballerina-display:
         label: "Reorder or Replace Tracks"
       parameters:
         - description: The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
@@ -354,7 +354,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Playlist Id"
         - description: |-
             A comma-separated list of [Spotify URIs](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) to set, can be track or episode URIs. For example: `uris=spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M,spotify:episode:512ojhOuo1ktJprKbVcKyQ`
@@ -364,7 +364,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "Track URIs"
       requestBody:
         content:
@@ -420,7 +420,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-list-users-playlists
       operationId: getPlayslistsByUserID
-      x-display:
+      x-ballerina-display:
         label: "Playlist By User Id"
       parameters:
         - description: The user's [Spotify user ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).
@@ -429,7 +429,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "User Id"
         - description: "The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50."
           in: query
@@ -438,7 +438,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Limit"
         - description: "The index of the first playlist to return. Default: 0 (the first object). Maximum offset: 100.000. Use with `limit` to get the next set of playlists."
           in: query
@@ -447,7 +447,7 @@ paths:
           schema:
             format: int32
             type: integer
-          x-display:
+          x-ballerina-display:
             label: "Offset"
       responses:
         "200":
@@ -473,7 +473,7 @@ paths:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#endpoint-create-playlist
       operationId: createPlaylist
-      x-display:
+      x-ballerina-display:
         label: "Create Playlist"
       parameters:
         - description: The user's [Spotify user ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).
@@ -482,7 +482,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: "User Id"
       requestBody:
         content:

--- a/openapi-cli/src/test/resources/generators/client/swagger/header_param_with_default_value.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/header_param_with_default_value.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: header
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: header
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/client/swagger/invalid_query_param.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/invalid_query_param.yaml
@@ -5,7 +5,7 @@ info:
     Get current weather, daily forecast for 16 days, and 3-hourly forecast 5
     days for your city.
   version: 1.0.0-oas3
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 servers:
   - url: 'http://api.openweathermap.org/data/2.5/'

--- a/openapi-cli/src/test/resources/generators/client/swagger/missing_server_url.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/missing_server_url.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 paths:
   /onecall:
@@ -21,7 +21,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -29,7 +29,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -37,7 +37,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -45,9 +45,9 @@ paths:
           required: false
           schema:
             type: integer
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/client/swagger/openapi_display_annotation.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/openapi_display_annotation.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: "CC Attribution-ShareAlike 4.0 (CC BY-SA 4.0)"
     url: "https://openweathermap.org/price"
-  x-display:
+  x-ballerina-display:
     label: "Current Weather Details"
     iconPath: "Path"
 
@@ -36,7 +36,7 @@ paths:
         - $ref: '#/components/parameters/units'
         - $ref: '#/components/parameters/lang'
         - $ref: '#/components/parameters/mode'
-      x-display:
+      x-ballerina-display:
         label: "Current weather"
       responses:
         200:
@@ -73,7 +73,7 @@ components:
       description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by comma; use ISO 3166 country codes."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "City name"
     id:
       name: id

--- a/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_advance_scenarios.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_advance_scenarios.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -41,7 +41,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -49,9 +49,9 @@ paths:
           required: false
           schema:
             type: integer
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_default_value.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_default_value.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/query_param_with_ref_schema.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/client/swagger/query_param_without_default_value.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/query_param_without_default_value.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -41,7 +41,7 @@ paths:
           required: false
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -49,9 +49,9 @@ paths:
           required: false
           schema:
             type: integer
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/nullable_null_type.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/nullable_null_type.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/nullable_option_null_type.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/nullable_option_null_type.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/nullable_option_string_type.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/nullable_option_string_type.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/nullable_string_type.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/nullable_string_type.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/openapi_weather_api.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/openapi_weather_api.yaml
@@ -69,7 +69,7 @@ components:
       description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by comma; use ISO 3166 country codes."
       schema:
         type: string
-      x-display:
+      x-ballerina-display:
         label: "City name"
     id:
       name: id

--- a/openapi-cli/src/test/resources/generators/schema/swagger/schema_referenced_in_parameters.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/schema_referenced_in_parameters.yaml
@@ -4,7 +4,7 @@ info:
   title: "OpenWeather Map API for Query parameter"
   description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city."
   version: "2.5.2"
-  x-display:
+  x-ballerina-display:
     label: Open Weather Client
 
 servers:
@@ -25,7 +25,7 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Latitude'
-          x-display:
+          x-ballerina-display:
             label: Latitude
         - description: "Longtitude"
           in: query
@@ -33,7 +33,7 @@ paths:
           required: true
           schema:
             type: string
-          x-display:
+          x-ballerina-display:
             label: Longtitude
         - description: "test"
           in: query
@@ -42,7 +42,7 @@ paths:
           schema:
             type: string
             default: 'current'
-          x-display:
+          x-ballerina-display:
             label: Exclude
         - description: 'tests'
           in: query
@@ -51,9 +51,9 @@ paths:
           schema:
             type: integer
             default: 12
-          x-display:
+          x-ballerina-display:
             label: Units
-      x-display:
+      x-ballerina-display:
         label: "Weather Forecast"
       responses:
         200:

--- a/openapi-cli/src/test/resources/x_init_description.yaml
+++ b/openapi-cli/src/test/resources/x_init_description.yaml
@@ -10,7 +10,7 @@ info:
   termsOfService: http://developer.nytimes.com/tou
   title: Movie Reviews API
   version: 2.0.0
-  x-init-description: >
+  x-ballerina-init-description: >
     Client initialization required API credentials and service URL.
 
     The service URL may set to the default value. You can override if required.


### PR DESCRIPTION
## Purpose
> $subject

## Goals
Rename the extensions that were introduced to include Ballerina related data

`x-display` -> `x-ballerina-display`
`x-init-description` -> `x-ballerina-init-description`
`x-apikey-description` -> `x-ballerina-apikey-description`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> Ubuntu 20.04