### PR TITLE
[Client] utils.bal file generation bug fix

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -251,6 +251,7 @@ public class FunctionBodyGenerator {
         } else {
 
             if (!queryApiKeyNameList.isEmpty()) {
+                ballerinaUtilGenerator.setQueryParamsFound(true);
                 statementsList.add(getMapForParameters(new ArrayList<>(), "map<anydata>",
                         "queryParam", queryApiKeyNameList));
                 // Add updated path


### PR DESCRIPTION
## Purpose
> When there is no query parameter is given in any of the operations, but query parameter api key is defined, relevant util functions to set the query parameters to the http:Request are not generated.  

## Goals
> Bug fix

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/ballerina-platform/ballerina-openapi/pull/562