### PR TITLE
[Client] Fix bug in multi line API key documentation generation

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaAuthConfigGenerator.java
@@ -31,7 +31,6 @@ import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
-import io.ballerina.compiler.syntax.tree.MarkdownDocumentationLineNode;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
 import io.ballerina.compiler.syntax.tree.NilLiteralNode;
@@ -47,13 +46,13 @@ import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.RequiredExpressionNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
-import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.generators.DocCommentsGenerator;
 import io.ballerina.openapi.generators.GeneratorConstants;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -80,7 +79,6 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createFieldAccessExp
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createImplicitNewExpressionNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createIntersectionTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMappingConstructorExpressionNode;
-import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationLineNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMetadataNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMethodCallExpressionNode;
@@ -649,11 +647,9 @@ public class BallerinaAuthConfigGenerator {
     }
 
     private MetadataNode getMetadataNode(String comment) {
-        MarkdownDocumentationLineNode markdownDocumentationLineNode =
-                createMarkdownDocumentationLineNode(null, createToken(SyntaxKind.HASH_TOKEN),
-                        createNodeList(createIdentifierToken(comment)));
+        List<Node> docs = new ArrayList<>(DocCommentsGenerator.createAPIDescriptionDoc(comment, false));
         MarkdownDocumentationNode authDocumentationNode = createMarkdownDocumentationNode(
-                createNodeList(markdownDocumentationLineNode));
+                createNodeList(docs));
         return createMetadataNode(authDocumentationNode, createEmptyNodeList());
     }
 

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/ApiKeyAuthTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/ApiKeyAuthTests.java
@@ -118,6 +118,22 @@ public class ApiKeyAuthTests {
         Assert.assertEquals(generatedConfigRecord, expectedConfigRecord);
     }
 
+    @Test(description = "Test ApiKeysConfig record documentation generation for multiline descriptions")
+    public void testConfigRecordDocumentationGen() throws IOException, BallerinaOpenApiException {
+        // generate ApiKeysConfig record
+        GeneratorUtils generatorUtils = new GeneratorUtils();
+        BallerinaAuthConfigGenerator ballerinaAuthConfigGenerator = new BallerinaAuthConfigGenerator(true, false);
+        String expectedConfigRecord = TestConstants.MULTI_LINE_API_KEY_DESC;
+        Path definitionPath = RES_DIR.resolve("auth/scenarios/api_key/multiline_api_key_desc.yaml");
+        OpenAPI openAPI = generatorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        String generatedConfigRecord = Objects.requireNonNull(
+                ballerinaAuthConfigGenerator.getConfigRecord(openAPI)).toString();
+        Assert.assertFalse(generatedConfigRecord.isBlank());
+        generatedConfigRecord = (generatedConfigRecord.trim()).replaceAll("\\s+", "");
+        expectedConfigRecord = (expectedConfigRecord.trim()).replaceAll("\\s+", "");
+        Assert.assertEquals(generatedConfigRecord, expectedConfigRecord);
+    }
+
     @DataProvider(name = "apiKeyAuthIOProvider")
     public Object[] dataProvider() {
         return new Object[]{

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestConstants.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestConstants.java
@@ -99,7 +99,6 @@ public class TestConstants {
             "    string apiXKey;\n" +
             "|};";
     public static final String API_KEY_ASSIGNMENT = "self.apiKeyConfig = apiKeyConfig.cloneReadOnly();";
-    public static final String DEFAULT_API_KEY_DOC_COMMENT = "API key configuration details";
     public static final String MULTIPLE_API_KEY_RECORD = "# Provides API key configurations needed when " +
             "communicating with a remote HTTP endpoint.\n" +
             "public type ApiKeysConfig record {|\n" +
@@ -108,6 +107,20 @@ public class TestConstants {
             "    # API key to authorize POST requests.\n" +
             "    string xApiKey;\n" +
             "|};";
-
-
+    public static final String MULTI_LINE_API_KEY_DESC = "# Provides API key configurations needed when " +
+            "communicating with a remote HTTP endpoint.\n" +
+            "public type ApiKeysConfig record {|\n" +
+            "    # To use API you have to sign up and get your own API key. Unify API accounts have sandbox mode and " +
+            "live mode API keys. To change modes just use the appropriate key to get a live or test object.\n" +
+            "    # Authenticate your API requests by including your test or live secret API key in the request " +
+            "header.\n" +
+            "    # You should use the public keys on the SDKs and the secret keys to authenticate API requests.\n" +
+            "    # **Do not share or include your secret API keys on client side code.** Your API keys carry " +
+            "significant privileges. Please ensure to keep them 100% secure and be sure to not share your secret " +
+            "API keys in areas that are publicly accessible like GitHub.\n" +
+            "    # Learn how to set the Authorization header inside Postman " +
+            "https://learning.postman.com/docs/postman/sending-api-requests/authorization/#api-key\n" +
+            "    # Go to Unify to grab your API KEY https://openweathermap/me/api-keys\n" +
+            "    string appid;\n" +
+            "|};";
 }

--- a/openapi-cli/src/test/resources/generators/client/auth/scenarios/api_key/multiline_api_key_desc.yaml
+++ b/openapi-cli/src/test/resources/generators/client/auth/scenarios/api_key/multiline_api_key_desc.yaml
@@ -1,0 +1,333 @@
+openapi: "3.0.1"
+
+info:
+  title: "OpenWeatherMap API"
+  description: "Get current weather, daily forecast for 16 days, and 3-hourly forecast 5 days for your city. Helpful stats, graphics, and this day in history charts are available for your reference. Interactive maps show precipitation, clouds, pressure, wind around your location stations. Data is available in JSON, XML, or HTML format. **Note**: This sample Swagger file covers the `current` endpoint only from the OpenWeatherMap API. <br/><br/> **Note**: All parameters are optional, but you must select at least one parameter. Calling the API by city ID (using the `id` parameter) will provide the most precise location results."
+  version: "2.5.2"
+  termsOfService: "https://openweathermap.org/terms"
+  contact:
+    name: "OpenWeatherMap API"
+    url: "https://openweathermap.org/api"
+    email: "some_email@gmail.com"
+  license:
+    name: "CC Attribution-ShareAlike 4.0 (CC BY-SA 4.0)"
+    url: "https://openweathermap.org/price"
+
+servers:
+  - url: "http://api.openweathermap.org/data/2.5/"
+
+paths:
+  /weather:
+    get:
+      tags:
+        - Current Weather Data
+      summary: "Call current weather data for one location"
+      description: "Access current weather data for any location on Earth including over 200,000 cities! Current weather is frequently updated based on global models and data from more than 40,000 weather stations."
+      operationId: CurrentWeatherData
+      parameters:
+        - $ref: '#/components/parameters/q'
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/lat'
+        - $ref: '#/components/parameters/lon'
+        - $ref: '#/components/parameters/zip'
+        - $ref: '#/components/parameters/units'
+        - $ref: '#/components/parameters/lang'
+        - $ref: '#/components/parameters/mode'
+
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200'
+        404:
+          description: Not found response
+          content:
+            text/plain:
+              schema:
+                title: Weather not found
+                type: string
+                example: Not found
+security:
+  - app_id: []
+
+tags:
+  - name: Current Weather Data
+    description: "Get current weather details"
+
+externalDocs:
+  description: API DocCommentsGenerator
+  url: https://openweathermap.org/api
+
+components:
+
+  parameters:
+    q:
+      name: q
+      in: query
+      description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by comma; use ISO 3166 country codes."
+      schema:
+        type: string
+    id:
+      name: id
+      in: query
+      description: "**City ID**. *Example: `2172797`*. You can call by city ID. API responds with exact result. The List of city IDs can be downloaded [here](http://bulk.openweathermap.org/sample/). You can include multiple cities in parameter &mdash; just separate them by commas. The limit of locations is 20. *Note: A single ID counts as a one API call. So, if you have city IDs. it's treated as 3 API calls.*"
+      schema:
+        type: string
+
+    lat:
+      name: lat
+      in: query
+      description: "**Latitude**. *Example: 35*. The latitude cordinate of the location of your interest. Must use with `lon`."
+      schema:
+        type: string
+
+    lon:
+      name: lon
+      in: query
+      description: "**Longitude**. *Example: 139*. Longitude cordinate of the location of your interest. Must use with `lat`."
+      schema:
+        type: string
+
+    zip:
+      name: zip
+      in: query
+      description: "**Zip code**. Search by zip code. *Example: 95050,us*. Please note if country is not specified then the search works for USA as a default."
+      schema:
+        type: string
+
+    units:
+      name: units
+      in: query
+      description: '**Units**. *Example: imperial*. Possible values: `standard`, `metric`, and `imperial`. When you do not use units parameter, format is `standard` by default.'
+      schema:
+        type: string
+        enum: [standard, metric, imperial]
+        default: "imperial"
+
+    lang:
+      name: lang
+      in: query
+      description: '**Language**. *Example: en*. You can use lang parameter to get the output in your language. We support the following languages that you can use with the corresponded lang values: Arabic - `ar`, Bulgarian - `bg`, Catalan - `ca`, Czech - `cz`, German - `de`, Greek - `el`, English - `en`, Persian (Farsi) - `fa`, Finnish - `fi`, French - `fr`, Galician - `gl`, Croatian - `hr`, Hungarian - `hu`, Italian - `it`, Japanese - `ja`, Korean - `kr`, Latvian - `la`, Lithuanian - `lt`, Macedonian - `mk`, Dutch - `nl`, Polish - `pl`, Portuguese - `pt`, Romanian - `ro`, Russian - `ru`, Swedish - `se`, Slovak - `sk`, Slovenian - `sl`, Spanish - `es`, Turkish - `tr`, Ukrainian - `ua`, Vietnamese - `vi`, Chinese Simplified - `zh_cn`, Chinese Traditional - `zh_tw`.'
+      schema:
+        type: string
+        enum: [ar, bg, ca, cz, de, el, en, fa, fi, fr, gl, hr, hu, it, ja, kr, la, lt, mk, nl, pl, pt, ro, ru, se, sk, sl, es, tr, ua, vi, zh_cn, zh_tw]
+        default: "en"
+
+    mode:
+      name: mode
+      in: query
+      description: "**Mode**. *Example: html*. Determines format of response. Possible values are `xml` and `html`. If mode parameter is empty the format is `json` by default."
+      schema:
+        type: string
+        enum: [json, xml, html]
+        default: "json"
+
+  schemas:
+    200:
+      title: Successful response
+      type: object
+      properties:
+        coord:
+          $ref: '#/components/schemas/Coord'
+        weather:
+          type: array
+          items:
+            $ref: '#/components/schemas/Weather'
+          description: (more info Weather condition codes)
+        base:
+          type: string
+          description: Internal parameter
+          example: cmc stations
+        main:
+          $ref: '#/components/schemas/Main'
+        visibility:
+          type: integer
+          description: Visibility, meter
+          example: 16093
+        wind:
+          $ref: '#/components/schemas/Wind'
+        clouds:
+          $ref: '#/components/schemas/Clouds'
+        rain:
+          $ref: '#/components/schemas/Rain'
+        snow:
+          $ref: '#/components/schemas/Snow'
+        dt:
+          type: integer
+          description: Time of data calculation, unix, UTC
+          format: int32
+          example: 1435658272
+        sys:
+          $ref: '#/components/schemas/Sys'
+        id:
+          type: integer
+          description: City ID
+          format: int32
+          example: 2172797
+        name:
+          type: string
+          example: Cairns
+        cod:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 200
+    Coord:
+      title: Coord
+      type: object
+      properties:
+        lon:
+          type: number
+          description: City geo location, longitude
+          example: 145.77000000000001
+        lat:
+          type: number
+          description: City geo location, latitude
+          example: -16.920000000000002
+    Weather:
+      title: Weather
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Weather condition id
+          format: int32
+          example: 803
+        main:
+          type: string
+          description: Group of weather parameters (Rain, Snow, Extreme etc.)
+          example: Clouds
+        description:
+          type: string
+          description: Weather condition within the group
+          example: broken clouds
+        icon:
+          type: string
+          description: Weather icon id
+          example: 04n
+    Main:
+      title: Main
+      type: object
+      properties:
+        temp:
+          type: number
+          description: 'Temperature. Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 293.25
+        pressure:
+          type: integer
+          description: Atmospheric pressure (on the sea level, if there is no sea_level or grnd_level data), hPa
+          format: int32
+          example: 1019
+        humidity:
+          type: integer
+          description: Humidity, %
+          format: int32
+          example: 83
+        temp_min:
+          type: number
+          description: 'Minimum temperature at the moment. This is deviation from current temp that is possible for large cities and megalopolises geographically expanded (use these parameter optionally). Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 289.81999999999999
+        temp_max:
+          type: number
+          description: 'Maximum temperature at the moment. This is deviation from current temp that is possible for large cities and megalopolises geographically expanded (use these parameter optionally). Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 295.37
+        sea_level:
+          type: number
+          description: Atmospheric pressure on the sea level, hPa
+          example: 984
+        grnd_level:
+          type: number
+          description: Atmospheric pressure on the ground level, hPa
+          example: 990
+    Wind:
+      title: Wind
+      type: object
+      properties:
+        speed:
+          type: number
+          description: 'Wind speed. Unit Default: meter/sec, Metric: meter/sec, Imperial: miles/hour.'
+          example: 5.0999999999999996
+        deg:
+          type: integer
+          description: Wind direction, degrees (meteorological)
+          format: int32
+          example: 150
+    Clouds:
+      title: Clouds
+      type: object
+      properties:
+        all:
+          type: integer
+          description: Cloudiness, %
+          format: int32
+          example: 75
+    Rain:
+      title: Rain
+      type: object
+      properties:
+        3h:
+          type: integer
+          description: Rain volume for the last 3 hours
+          format: int32
+          example: 3
+    Snow:
+      title: Snow
+      type: object
+      properties:
+        3h:
+          type: number
+          description: Snow volume for the last 3 hours
+          example: 6
+    Sys:
+      title: Sys
+      type: object
+      properties:
+        type:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 1
+        id:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 8166
+        message:
+          type: number
+          description: Internal parameter
+          example: 0.0166
+        country:
+          type: string
+          description: Country code (GB, JP etc.)
+          example: AU
+        sunrise:
+          type: integer
+          description: Sunrise time, unix, UTC
+          format: int32
+          example: 1435610796
+        sunset:
+          type: integer
+          description: Sunset time, unix, UTC
+          format: int32
+          example: 1435650870
+
+  securitySchemes:
+    app_id:
+      type: apiKey
+      description: >
+        To use API you have to sign up and get your own API key. Unify API accounts have sandbox mode and live mode API keys.
+        To change modes just use the appropriate key to get a live or test object.
+
+        Authenticate your API requests by including your test or live secret API key in the request header.
+
+        You should use the public keys on the SDKs and the secret keys to authenticate API requests.
+
+        **Do not share or include your secret API keys on client side code.** Your API keys carry significant privileges. Please ensure to keep them 100% secure and be sure to not share your secret API keys in areas that are publicly accessible like GitHub.
+
+        Learn how to set the Authorization header inside Postman https://learning.postman.com/docs/postman/sending-api-requests/authorization/#api-key
+
+        Go to Unify to grab your API KEY https://openweathermap/me/api-keys
+      name: appid
+      in: query


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/ballerina-openapi/issues/617

## Goals

#### Sample OpenAPI

```
  securitySchemes:
    apiKey:
      description: >
        To use API you have to sign up and get your own API key. Unify API accounts have sandbox mode and live mode API keys. 
        To change modes just use the appropriate key to get a live or test object. You can find your API keys on the unify settings of your Apideck app.
        Your Apideck application_id can also be found on the same page.

        Go to Unify to grab your API KEY https://app.apideck.com/unify/api-keys
      in: header
      name: Authorization
      type: apiKey
```
#### Generated code after the fix

```ballerina
# Provides API key configurations needed when communicating with a remote HTTP endpoint.
public type ApiKeysConfig record {|
    # To use API you have to sign up and get your own API key. Unify API accounts have sandbox mode and live mode API keys.
    # To change modes just use the appropriate key to get a live or test object. You can find your API keys on the unify settings of your Apideck app.
    # Your Apideck application_id can also be found on the same page.
    # Go to Unify to grab your API KEY https://app.apideck.com/unify/api-keys
    string authorization;
|};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11