### PR TITLE
[Schema] Fix `type.bal` content when using OpenAPI to Ballerina command to generate both client and service files

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
@@ -153,11 +153,12 @@ public class CodeGenerator {
             throws IOException, BallerinaOpenApiException, FormatterException {
         Path srcPath = Paths.get(outPath);
         Path implPath = CodegenUtils.getImplPath(srcPackage, srcPath);
-        List<GenSrcFile> genFiles = new ArrayList<>();
-        genFiles.addAll(generateBalSource(GEN_SERVICE, definitionPath, serviceName, filter, nullable));
-        genFiles.addAll(generateBalSource(GEN_CLIENT, definitionPath, serviceName, filter,
+        List<GenSrcFile> genSrcFiles = generateBalSource(GEN_SERVICE, definitionPath, serviceName, filter, nullable)
+                .stream().filter(genSrcFile -> !genSrcFile.getFileName().equals(TYPE_FILE_NAME))
+                        .collect(Collectors.toList());
+        genSrcFiles.addAll(generateBalSource(GEN_CLIENT, definitionPath, serviceName, filter,
                 nullable));
-        List<GenSrcFile> newGenFiles = genFiles.stream().filter(distinctByKey(
+        List<GenSrcFile> newGenFiles = genSrcFiles.stream().filter(distinctByKey(
                 GenSrcFile::getFileName)).collect(Collectors.toList());
         writeGeneratedSources(newGenFiles, srcPath, implPath, type);
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -509,7 +509,7 @@ public class CodeGeneratorTest {
     private String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
 
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));
-        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining("\n"));
+        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining(System.lineSeparator()));
         expectedServiceLines.close();
         return expectedServiceContent;
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -38,6 +38,8 @@ import java.util.stream.Stream;
  * OpenAPI command test suit.
  */
 public class OpenAPICmdTest extends OpenAPICommandTest {
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+
     @BeforeTest(description = "This will create a new ballerina project for testing below scenarios.")
     public void setupBallerinaProject() throws IOException {
         super.setup();
@@ -82,7 +84,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         Path expectedSchemaFile = resourceDir.resolve(Paths.get("expected_gen", "petstore_schema.bal"));
         String expectedSchemaContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
-            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -93,7 +95,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
-                generatedSchema = generatedSchemaLines.collect(Collectors.joining("\n"));
+                generatedSchema = generatedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -123,7 +125,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         Path expectedSchemaFile = resourceDir.resolve(Paths.get("expected_gen", "petstore_schema_type.bal"));
         String expectedSchemaContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
-            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -134,7 +136,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
-                generatedSchema = generatedSchemaLines.collect(Collectors.joining("\n"));
+                generatedSchema = generatedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -142,12 +144,11 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             expectedSchemaContent = (expectedSchemaContent.trim()).replaceAll("\\s+", "");
             if (expectedSchemaContent.equals(generatedSchema)) {
                 Assert.assertTrue(true);
-                deleteGeneratedFiles(false);
             } else {
                 Assert.fail("Expected content and actual generated content is mismatched for: "
                         + petstoreYaml.toString());
-                deleteGeneratedFiles(false);
             }
+            deleteGeneratedFiles(false);
         } else {
             Assert.fail("Type generation failed. : " + readOutput(true));
         }
@@ -166,7 +167,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
                 "petstore_schema_with_license.bal"));
         String expectedSchemaContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
-            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -177,7 +178,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
-                generatedSchema = generatedSchemaLines.collect(Collectors.joining("\n"));
+                generatedSchema = generatedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -185,12 +186,11 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             expectedSchemaContent = (expectedSchemaContent.trim()).replaceAll("\\s+", "");
             if (expectedSchemaContent.equals(generatedSchema)) {
                 Assert.assertTrue(true);
-                deleteGeneratedFiles(false);
             } else {
                 Assert.fail("Expected content and actual generated content is mismatched for: "
                         + petstoreYaml.toString());
-                deleteGeneratedFiles(false);
             }
+            deleteGeneratedFiles(false);
         } else {
             Assert.fail("Code generation failed. : " + readOutput(true));
         }
@@ -209,7 +209,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
                 "generated_client_with_license.bal"));
         String expectedClientContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
-            expectedClientContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedClientContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -220,7 +220,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedClientContent = "";
             try (Stream<String> generatedClientLines = Files.lines(this.tmpDir.resolve("client.bal"))) {
-                generatedClientContent = generatedClientLines.collect(Collectors.joining("\n"));
+                generatedClientContent = generatedClientLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -251,7 +251,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
                 "client_filtered_by_tags.bal"));
         String expectedClientContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedClientFile)) {
-            expectedClientContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedClientContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -262,7 +262,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare client contents
             String generatedClientContent = "";
             try (Stream<String> generatedClientLines = Files.lines(this.tmpDir.resolve("client.bal"))) {
-                generatedClientContent = generatedClientLines.collect(Collectors.joining("\n"));
+                generatedClientContent = generatedClientLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -294,7 +294,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
                 "bearer_config.toml"));
         String expectedConfig = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedConfigFilePath)) {
-            expectedConfig = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedConfig = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -306,7 +306,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedConfig = "";
             try (Stream<String> configContent = Files.lines(this.tmpDir.resolve("tests/Config.toml"))) {
-                generatedConfig = configContent.collect(Collectors.joining("\n"));
+                generatedConfig = configContent.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -351,7 +351,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         Path expectedSchemaFile = resourceDir.resolve(Paths.get("expected_gen", "petstore_schema.bal"));
         String expectedSchemaContent = "";
         try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
-            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
@@ -362,7 +362,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
-                generatedSchema = generatedSchemaLines.collect(Collectors.joining("\n"));
+                generatedSchema = generatedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -112,6 +112,47 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
     }
 
+    @Test(description = "Check the type content in openapi-to-ballerina command when using to generate both " +
+            "client and service")
+    public void testSuccessfulTypeBalGeneration() throws IOException {
+        Path petstoreYaml = resourceDir.resolve(Paths.get("petstore_type.yaml"));
+        String[] args = {"--input", petstoreYaml.toString(), "-o", this.tmpDir.toString()};
+        OpenApiCmd cmd = new OpenApiCmd(printStream, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Path expectedSchemaFile = resourceDir.resolve(Paths.get("expected_gen", "petstore_schema_type.bal"));
+        String expectedSchemaContent = "";
+        try (Stream<String> expectedSchemaLines = Files.lines(expectedSchemaFile)) {
+            expectedSchemaContent = expectedSchemaLines.collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+        if (Files.exists(this.tmpDir.resolve("client.bal")) &&
+                Files.exists(this.tmpDir.resolve("petstore_type_service.bal")) &&
+                Files.exists(this.tmpDir.resolve("types.bal")) &&
+                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+            //Compare schema contents
+            String generatedSchema = "";
+            try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
+                generatedSchema = generatedSchemaLines.collect(Collectors.joining("\n"));
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+            generatedSchema = (generatedSchema.trim()).replaceAll("\\s+", "");
+            expectedSchemaContent = (expectedSchemaContent.trim()).replaceAll("\\s+", "");
+            if (expectedSchemaContent.equals(generatedSchema)) {
+                Assert.assertTrue(true);
+                deleteGeneratedFiles(false);
+            } else {
+                Assert.fail("Expected content and actual generated content is mismatched for: "
+                        + petstoreYaml.toString());
+                deleteGeneratedFiles(false);
+            }
+        } else {
+            Assert.fail("Type generation failed. : " + readOutput(true));
+        }
+    }
+
     @Test(description = "Test openapi to ballerina generation with license headers")
     public void testGenerationWithLicenseHeaders() throws IOException {
         Path petstoreYaml = resourceDir.resolve(Paths.get("petstore.yaml"));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestUtils.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestUtils.java
@@ -58,6 +58,7 @@ public class TestUtils {
     private static final Path clientPath = RES_DIR.resolve("ballerina_project/client.bal");
     private static final Path schemaPath = RES_DIR.resolve("ballerina_project/types.bal");
     private static final Path utilPath = RES_DIR.resolve("ballerina_project/utils.bal");
+    private static final String LINE_SEPARATOR = System.lineSeparator();
     List<String> list1 = new ArrayList<>();
     List<String> list2 = new ArrayList<>();
     Filter filter = new Filter(list1, list2);
@@ -80,9 +81,9 @@ public class TestUtils {
     //Get string as a content of ballerina file
     public static String getStringFromGivenBalFile(Path expectedServiceFile) throws IOException {
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile);
-        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining("\n"));
+        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining(LINE_SEPARATOR));
         expectedServiceLines.close();
-        return expectedServiceContent.replaceAll("\n", "");
+        return expectedServiceContent.replaceAll(LINE_SEPARATOR, "");
     }
 
     public static void compareGeneratedSyntaxTreeWithExpectedSyntaxTree(Path path, SyntaxTree syntaxTree)
@@ -90,7 +91,7 @@ public class TestUtils {
 
         String expectedBallerinaContent = getStringFromGivenBalFile(path);
         String generatedSyntaxTree = syntaxTree.toString();
-        generatedSyntaxTree = generatedSyntaxTree.replaceAll("\n", "");
+        generatedSyntaxTree = generatedSyntaxTree.replaceAll(LINE_SEPARATOR, "");
         generatedSyntaxTree = (generatedSyntaxTree.trim()).replaceAll("\\s+", "");
         expectedBallerinaContent = (expectedBallerinaContent.trim()).replaceAll("\\s+", "");
         Assert.assertTrue(generatedSyntaxTree.equals(expectedBallerinaContent));
@@ -142,7 +143,7 @@ public class TestUtils {
 
     public static String  getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));
-        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining("\n"));
+        String expectedServiceContent = expectedServiceLines.collect(Collectors.joining(LINE_SEPARATOR));
         expectedServiceLines.close();
         return expectedServiceContent;
     }

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
@@ -1,0 +1,7 @@
+public type PetArr Pet[];
+
+public type Pet record {
+    int petId;
+    string name;
+    string petType?;
+};

--- a/openapi-cli/src/test/resources/petstore_type.yaml
+++ b/openapi-cli/src/test/resources/petstore_type.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.1
+info:
+  title: Hello
+  version: 1.0.0
+servers:
+  - url: "{server}:{port}/hello"
+    variables:
+      server:
+        default: http://petstore.openapi.io
+      port:
+        default: "80"
+paths:
+  /pet/{id}:
+    get:
+      summary: Getting pet by givning petId
+      operationId: "operation_get_/pet/{id}"
+      parameters:
+        - name: id
+          in: path
+          description: 'Pet Id '
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+  /pets:
+    get:
+      summary: Getting all the pets in the list
+      operationId: operation_get_/pets
+      parameters:
+        - name: offset
+          in: query
+          description: Number of retriving items
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+  /hello:
+    get:
+      operationId: operation_get_/hello
+      parameters:
+        - name: pet
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+components:
+  schemas:
+    Pet:
+      required:
+        - name
+        - petId
+      type: object
+      properties:
+        petId:
+          type: integer
+          format: int32
+        name:
+          type: string
+        petType:
+          type: string


### PR DESCRIPTION
Fix #686 

## Automation tests
 - Integration tests -- added
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> Java JDK 11
