### PR TITLE
Remove `exitError`  code from success command execution

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OpenApiCmd.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OpenApiCmd.java
@@ -152,7 +152,6 @@ public class OpenApiCmd implements BLauncherCmd {
                 }
             } else if (fileName.endsWith(BAL_EXTENSION)) {
                 ballerinaToOpenApi(fileName);
-                exitError(this.exitWhenFinish);
             } else {
                 outStream.println(OpenApiMesseges.MESSAGE_FOR_MISSING_INPUT);
                 exitError(this.exitWhenFinish);


### PR DESCRIPTION
## Purpose
> $Subject

## Test environment
> Java JDK 11
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.