### PR TITLE
Add LS capability registration

### DIFF
--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/Constants.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/Constants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.openapi.extension;
+
+/**
+ * Represents the Service constants.
+ *
+ * @since 2.0.0
+ */
+public class Constants {
+
+    public static final String CAPABILITY_NAME = "openAPILSExtension";
+}

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilities.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilities.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.openapi.extension;
+
+import org.ballerinalang.langserver.commons.registration.BallerinaClientCapability;
+
+/**
+ * Client capabilities for the open API service.
+ *
+ * @since 2.0.0
+ */
+public class OpenAPIClientCapabilities extends BallerinaClientCapability {
+
+    private boolean generateOpenAPI;
+
+    public boolean isGenerateOpenAPI() {
+
+        return generateOpenAPI;
+    }
+
+    public void setGenerateOpenAPI(boolean generateOpenAPI) {
+
+        this.generateOpenAPI = generateOpenAPI;
+    }
+
+    public OpenAPIClientCapabilities() {
+        super(Constants.CAPABILITY_NAME);
+    }
+}

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilities.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilities.java
@@ -26,17 +26,15 @@ public class OpenAPIClientCapabilities extends BallerinaClientCapability {
 
     private boolean generateOpenAPI;
 
-    public boolean isGenerateOpenAPI() {
+    public OpenAPIClientCapabilities() {
+        super(OpenAPIServiceConstants.CAPABILITY_NAME);
+    }
 
+    public boolean isGenerateOpenAPI() {
         return generateOpenAPI;
     }
 
     public void setGenerateOpenAPI(boolean generateOpenAPI) {
-
         this.generateOpenAPI = generateOpenAPI;
-    }
-
-    public OpenAPIClientCapabilities() {
-        super(Constants.CAPABILITY_NAME);
     }
 }

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilitySetter.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilitySetter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.openapi.extension;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter;
+
+/**
+ * Client Capability setter for the {@link OpenAPIConverterService}.
+ *
+ * @since 2.0.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter")
+public class OpenAPIClientCapabilitySetter extends
+        BallerinaClientCapabilitySetter<OpenAPIClientCapabilities> {
+
+    @Override
+    public String getCapabilityName() {
+        return Constants.CAPABILITY_NAME;
+    }
+
+    @Override
+    public Class<OpenAPIClientCapabilities> getCapability() {
+        return OpenAPIClientCapabilities.class;
+    }
+}

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilitySetter.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIClientCapabilitySetter.java
@@ -29,7 +29,7 @@ public class OpenAPIClientCapabilitySetter extends
 
     @Override
     public String getCapabilityName() {
-        return Constants.CAPABILITY_NAME;
+        return OpenAPIServiceConstants.CAPABILITY_NAME;
     }
 
     @Override

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
@@ -28,6 +28,7 @@ import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerSe
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -47,6 +48,12 @@ import java.util.concurrent.CompletableFuture;
 @JsonSegment("openAPILSExtension")
 public class OpenAPIConverterService implements ExtendedLanguageServerService {
     private WorkspaceManager workspaceManager;
+
+    @Override
+    public void init(LanguageServer langServer, WorkspaceManager workspaceManager) {
+
+        this.workspaceManager = workspaceManager;
+    }
 
     public OpenAPIConverterService(WorkspaceManager workspaceManager) {
         this.workspaceManager = workspaceManager;

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
@@ -51,7 +51,6 @@ public class OpenAPIConverterService implements ExtendedLanguageServerService {
 
     @Override
     public void init(LanguageServer langServer, WorkspaceManager workspaceManager) {
-
         this.workspaceManager = workspaceManager;
     }
 

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIConverterService.java
@@ -86,7 +86,7 @@ public class OpenAPIConverterService implements ExtendedLanguageServerService {
             } else {
                 response.setError(null);
                 List<OASResult> yamlContent = ServiceToOpenAPIConverterUtils.generateOAS3Definition(
-                        syntaxTree.orElseThrow(), semanticModel.orElseThrow(), null, false,
+                        syntaxTree.get(), semanticModel.get(), null, false,
                         null);
                 //Response should handle
                 if (!yamlContent.isEmpty() && (yamlContent.get(0).getOpenAPI().isPresent())) {

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilities.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilities.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.openapi.extension;
+
+import org.ballerinalang.langserver.commons.registration.BallerinaServerCapability;
+
+/**
+ * Server capabilities for the OpenAPI converter service.
+ *
+ * @since 2.0.0
+ */
+public class OpenAPIServerCapabilities extends BallerinaServerCapability {
+
+    private boolean generateOpenAPI;
+
+    public boolean isGenerateOpenAPI() {
+
+        return generateOpenAPI;
+    }
+
+    public void setGenerateOpenAPI(boolean generateOpenAPI) {
+
+        this.generateOpenAPI = generateOpenAPI;
+    }
+
+    public OpenAPIServerCapabilities() {
+        super(Constants.CAPABILITY_NAME);
+    }
+}

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilities.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilities.java
@@ -26,17 +26,15 @@ public class OpenAPIServerCapabilities extends BallerinaServerCapability {
 
     private boolean generateOpenAPI;
 
-    public boolean isGenerateOpenAPI() {
+    public OpenAPIServerCapabilities() {
+        super(OpenAPIServiceConstants.CAPABILITY_NAME);
+    }
 
+    public boolean isGenerateOpenAPI() {
         return generateOpenAPI;
     }
 
     public void setGenerateOpenAPI(boolean generateOpenAPI) {
-
         this.generateOpenAPI = generateOpenAPI;
-    }
-
-    public OpenAPIServerCapabilities() {
-        super(Constants.CAPABILITY_NAME);
     }
 }

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilitySetter.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilitySetter.java
@@ -31,7 +31,6 @@ public class OpenAPIServerCapabilitySetter extends
 
     @Override
     public Optional<OpenAPIServerCapabilities> build() {
-
         OpenAPIServerCapabilities capabilities = new OpenAPIServerCapabilities();
         capabilities.setGenerateOpenAPI(true);
         return Optional.of(capabilities);
@@ -39,7 +38,7 @@ public class OpenAPIServerCapabilitySetter extends
 
     @Override
     public String getCapabilityName() {
-        return Constants.CAPABILITY_NAME;
+        return OpenAPIServiceConstants.CAPABILITY_NAME;
     }
 
     @Override

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilitySetter.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServerCapabilitySetter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.openapi.extension;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter;
+
+import java.util.Optional;
+
+/**
+ * Capability setter for the {@link OpenAPIConverterService}.
+ *
+ * @since 2.0.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter")
+public class OpenAPIServerCapabilitySetter extends
+        BallerinaServerCapabilitySetter<OpenAPIServerCapabilities> {
+
+    @Override
+    public Optional<OpenAPIServerCapabilities> build() {
+
+        OpenAPIServerCapabilities capabilities = new OpenAPIServerCapabilities();
+        capabilities.setGenerateOpenAPI(true);
+        return Optional.of(capabilities);
+    }
+
+    @Override
+    public String getCapabilityName() {
+        return Constants.CAPABILITY_NAME;
+    }
+
+    @Override
+    public Class<OpenAPIServerCapabilities> getCapability() {
+        return OpenAPIServerCapabilities.class;
+    }
+}

--- a/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServiceConstants.java
+++ b/openapi-ls-extension/src/main/java/io/ballerina/openapi/extension/OpenAPIServiceConstants.java
@@ -20,7 +20,7 @@ package io.ballerina.openapi.extension;
  *
  * @since 2.0.0
  */
-public class Constants {
+public class OpenAPIServiceConstants {
 
     public static final String CAPABILITY_NAME = "openAPILSExtension";
 }


### PR DESCRIPTION
## Purpose
> Add LS capability registration.

## Goals
> Since ballerina sl-beta4, language server extensions are not working unless the capabilities are registered.
