### PR TITLE
[Client] Support integer, boolean types in request header

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaUtilGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaUtilGenerator.java
@@ -212,9 +212,10 @@ public class BallerinaUtilGenerator {
      */
     private void getUtilTypeDeclarationNodes(List<ModuleMemberDeclarationNode> memberDeclarationNodes) {
         if (requestBodyEncodingFound || queryParamsFound) {
-            memberDeclarationNodes.addAll(Arrays.asList(
-                    getEncodingRecord(), getStyleEnum(), getSimpleBasicTypeDefinitionNode(), getDefaultEncoding()
-            ));
+            memberDeclarationNodes.addAll(Arrays.asList(getEncodingRecord(), getStyleEnum(), getDefaultEncoding()));
+        }
+        if (requestBodyEncodingFound || queryParamsFound || headersFound) {
+            memberDeclarationNodes.add(getSimpleBasicTypeDefinitionNode());
         }
     }
 

--- a/openapi-cli/src/main/resources/templates/utils.bal
+++ b/openapi-cli/src/main/resources/templates/utils.bal
@@ -233,6 +233,14 @@ isolated function getMapForHeaders(map<any> headerParam) returns map<string|stri
     foreach var [key, value] in headerParam.entries() {
         if value is string || value is string[] {
             headerMap[key] = value;
+        } else if value is int[] {
+            string[] stringArray = [];
+            foreach int intValue in value {
+               stringArray.push(intValue.toString());
+            }
+            headerMap[key] = stringArray;
+        } else if value is SimpleBasicType {
+            headerMap[key] = value.toString();
         }
     }
     return headerMap;

--- a/openapi-cli/src/test/resources/expected_gen/utils.bal
+++ b/openapi-cli/src/test/resources/expected_gen/utils.bal
@@ -15,9 +15,9 @@ enum EncodingStyle {
     PIPEDELIMITED
 }
 
-type SimpleBasicType string|boolean|int|float|decimal;
-
 final Encoding & readonly defaultEncoding = {};
+
+type SimpleBasicType string|boolean|int|float|decimal;
 
 # Serialize the record according to the deepObject style.
 #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
@@ -29,13 +29,15 @@ public isolated client class Client {
     # + lon - Longtitude
     # + exclude - test
     # + units - tests
+    # + idList - ID list
+    # + locationList - Location list
     # + return - Successful response
     @display {label: "Weather Forecast"}
-    remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = ()) returns WeatherForecast|error {
+    remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = (), @display {label: "ID List"} int[]? idList = (), @display {label: "Location List"} Location[]? locationList = ()) returns WeatherForecast|error {
         string  path = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "appid": self.apiKeyConfig.appid};
         path = path + check getPathForQueryParam(queryParam);
-        map<any> headerValues = {"exclude": exclude, "units": units};
+        map<any> headerValues = {"exclude": exclude, "units": units, "idList": idList, "locationList": locationList};
         map<string|string[]> accHeaders = getMapForHeaders(headerValues);
         WeatherForecast response = check self.clientEp-> get(path, accHeaders);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
@@ -24,10 +24,11 @@ public isolated client class Client {
     #
     # + xRequestId - Tests header 01
     # + xRequestClient - Tests header 02
+    # + xRequestPet - Tests header 03
     # + return - Expected response to a valid request
-    remote isolated function showPetById(string xRequestId, string[] xRequestClient) returns http:Response|error {
+    remote isolated function showPetById(string xRequestId, string[] xRequestClient, Pet[] xRequestPet) returns http:Response|error {
         string  path = string `/pets`;
-        map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-API-KEY": self.apiKeyConfig.xApiKey};
+        map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-Request-Pet": xRequestPet, "X-API-KEY": self.apiKeyConfig.xApiKey};
         map<string|string[]> accHeaders = getMapForHeaders(headerValues);
         http:Response response = check self.clientEp-> get(path, accHeaders);
         return response;

--- a/openapi-cli/src/test/resources/generators/client/swagger/header_optional.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/header_optional.yaml
@@ -51,6 +51,26 @@ paths:
             type: integer
           x-ballerina-display:
             label: Units
+        - description: 'ID list'
+          in: header
+          name: idList
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+          x-ballerina-display:
+            label: ID List
+        - description: 'Location list'
+          in: header
+          name: locationList
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Location'
+          x-ballerina-display:
+            label: Location List
       x-ballerina-display:
         label: "Weather Forecast"
       responses:
@@ -80,6 +100,13 @@ tags:
 components:
   schemas:
     WeatherForecast:
+      type: object
+      properties:
+        lat:
+          type: number
+        lon:
+          type: number
+    Location:
       type: object
       properties:
         lat:

--- a/openapi-cli/src/test/resources/generators/client/swagger/header_parameter.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/header_parameter.yaml
@@ -42,6 +42,14 @@ paths:
               type: string
               format: uuid
           required: true
+        - in: header
+          description: Tests header 03
+          name: X-Request-Pet
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"
+          required: true
       responses:
         '200':
           description: Expected response to a valid request
@@ -64,6 +72,20 @@ components:
           type: integer
           format: int32
         message:
+          type: string
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
           type: string
   securitySchemes:
     X-API-KEY:


### PR DESCRIPTION
## Purpose
Support integer, boolean types in request header.

## Goals
Fixes https://github.com/ballerina-platform/ballerina-openapi/issues/730

## Automation tests
 - Unit tests 
  Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
