### PR TITLE
[OpenAPIValidator] Fix issue with OpenAPI validator plugin has multiple service node

### DIFF
--- a/openapi-validator/src/main/java/io/ballerina/openapi/validator/ServiceValidator.java
+++ b/openapi-validator/src/main/java/io/ballerina/openapi/validator/ServiceValidator.java
@@ -100,10 +100,13 @@ public class ServiceValidator implements AnalysisTask<SyntaxNodeAnalysisContext>
             // Load a service declarations for the path part in the yaml spec
             if (syntaxKind.equals(SyntaxKind.SERVICE_DECLARATION)) {
                 ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) node;
-                location = serviceDeclarationNode.location();
-                // Check annotation is available
-                kind = getDiagnosticFromServiceNode(functions, kind, filters, semanticModel, syntaxTree,
-                        ballerinaFilePath, serviceDeclarationNode);
+                Optional<MetadataNode> metadata = serviceDeclarationNode.metadata();
+                if (metadata.isPresent()) {
+                    location = serviceDeclarationNode.location();
+                    // Check annotation is available
+                    kind = getDiagnosticFromServiceNode(functions, kind, filters, semanticModel, syntaxTree,
+                            ballerinaFilePath, serviceDeclarationNode);
+                }
             }
         }
         if (!validations.isEmpty()) {


### PR DESCRIPTION
## Purpose
> Fix #735 
The below example will give a compiler issue.
```ballerina
import ballerina/http;
import ballerina/openapi;

@openapi:ServiceInfo {
    title: "Mock Title",
    'version: "1.0.0"
}

service /mTitle on new http:Listener(9090) {
    resource function get title() returns string {
        return "Hello, World!";
    }
}
service /mVersion on new http:Listener(9090) {
    resource function get versions() returns string {
        return "Hello, World!";
    }
}
```

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage
## Test environment
>Java JDK 11 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.